### PR TITLE
Make CI only run once per PR/push

### DIFF
--- a/.github/workflows/linting_checks.yml
+++ b/.github/workflows/linting_checks.yml
@@ -1,6 +1,10 @@
 name: checks
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Following discussion here https://github.com/brainglobe/cellfinder-core/pull/29#discussion_r810246314 clearly we don't want the CI to run many times

Currently, if pushes are made to an open PR then the CI is effectively ran twice i.e.
![image](https://user-images.githubusercontent.com/15052188/154988324-4b762872-763f-4ea3-8f0e-b0ec42b1a582.png)

Following discussions on here https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/3 and explanation here https://tjtelan.com/blog/github-actions-push-vs-pr-workflow/ this is an easy way to avoid that