### PR TITLE
Add `types-setuptools` as a `mypy` dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,5 @@ repos:
       rev: v0.931
       hooks:
           - id: mypy
+            additional_dependencies:
+                - types-setuptools


### PR DESCRIPTION
This fixes #31, I'm a bit confused why I had to do this but appears to be the reason why it was failing before https://github.com/brainglobe/cellfinder-core/runs/5305547649?check_suite_focus=true