### PR TITLE
Add ability to externally query detection progress

### DIFF
--- a/cellfinder_core/detect/__init__.py
+++ b/cellfinder_core/detect/__init__.py
@@ -1,0 +1,1 @@
+from .detect import DetectRunner

--- a/cellfinder_core/detect/detect.py
+++ b/cellfinder_core/detect/detect.py
@@ -96,6 +96,7 @@ class DetectRunner:
         """
         n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
         self.start_time = datetime.now()
+        self.signal_array = signal_array
 
         (
             soma_diameter,
@@ -186,6 +187,11 @@ class DetectRunner:
             prev_lock = lock
             self.processes.append(p)
             p.start()
+
+    @property
+    def nplanes(self):
+        """Number of planes being processed."""
+        return len(self.signal_array)
 
     def join(self):
         """

--- a/cellfinder_core/detect/detect.py
+++ b/cellfinder_core/detect/detect.py
@@ -38,119 +38,172 @@ def calculate_parameters_in_pixels(
     return soma_diameter, max_cluster_size, ball_xy_size, ball_z_size
 
 
-def main(
-    signal_array,
-    start_plane,
-    end_plane,
-    voxel_sizes,
-    soma_diameter,
-    max_cluster_size,
-    ball_xy_size,
-    ball_z_size,
-    ball_overlap_fraction,
-    soma_spread_factor,
-    n_free_cpus,
-    log_sigma_size,
-    n_sds_above_mean_thresh,
-    outlier_keep=False,
-    artifact_keep=False,
-    save_planes=False,
-    plane_directory=None,
-):
-    n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
-    start_time = datetime.now()
+class DetectRunner:
+    def __init__(self):
+        """
+        A class for running detection.
 
-    (
-        soma_diameter,
-        max_cluster_size,
-        ball_xy_size,
-        ball_z_size,
-    ) = calculate_parameters_in_pixels(
+        The API of this class mimics that of `multiprocessing.Proces
+        `, providing ``.start()`` to start the detection processes and
+        ``.join()`` to block execution until detection is complete and return
+        the results.
+
+        While the processes are running progress can be queried by getting
+        items from ``self.planes_done_queue``, which stores the plane ids that
+        have been processed.
+
+        Attributes
+        ----------
+        planes_done_queue : multiprocessing.Queue
+            Stores the plane IDs that have been processed. Can be used to
+            externally query the progress of the MP3D filter.
+        """
+        self.planes_done_queue = MultiprocessingQueue()
+
+    def __call__(self, *args, **kwargs):
+        """
+        Run detection.
+        """
+        self.start(*args, **kwargs)
+        return self.join()
+
+    def start(
+        self,
+        signal_array,
+        start_plane,
+        end_plane,
         voxel_sizes,
         soma_diameter,
         max_cluster_size,
         ball_xy_size,
         ball_z_size,
-    )
-
-    if end_plane == -1:
-        end_plane = len(signal_array)
-    signal_array = signal_array[start_plane:end_plane]
-
-    workers_queue = MultiprocessingQueue(maxsize=n_processes)
-    # WARNING: needs to be AT LEAST ball_z_size
-    mp_3d_filter_queue = MultiprocessingQueue(maxsize=ball_z_size)
-    for plane_id in range(n_processes):
-        # place holder for the queue to have the right size on first run
-        workers_queue.put(None)
-
-    if signal_array.ndim != 3:
-        raise IOError("Input data must be 3D")
-
-    setup_params = [
-        signal_array[0, :, :],
-        soma_diameter,
-        ball_xy_size,
-        ball_z_size,
         ball_overlap_fraction,
-        start_plane,
-    ]
-    output_queue = MultiprocessingQueue()
+        soma_spread_factor,
+        n_free_cpus,
+        log_sigma_size,
+        n_sds_above_mean_thresh,
+        outlier_keep=False,
+        artifact_keep=False,
+        save_planes=False,
+        plane_directory=None,
+    ):
+        """
+        Start running the detection algorithm.
 
-    mp_3d_filter = Mp3DFilter(
-        mp_3d_filter_queue,
-        output_queue,
-        soma_diameter,
-        setup_params=setup_params,
-        soma_size_spread_factor=soma_spread_factor,
-        planes_paths_range=signal_array,
-        save_planes=save_planes,
-        plane_directory=plane_directory,
-        start_plane=start_plane,
-        max_cluster_size=max_cluster_size,
-        outlier_keep=outlier_keep,
-        artifact_keep=artifact_keep,
-    )
+        This will spawn processes that carry out the detection algorithm,
+        allowing code to continue executing elsewhere whilst work is being
+        done. To block until finished and get the results call ``.finish()``.
+        """
+        n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
+        self.start_time = datetime.now()
 
-    # start 3D analysis (waits for planes in queue)
-    bf_process = multiprocessing.Process(target=mp_3d_filter.process, args=())
-    bf_process.start()  # needs to be started before the loop
-    clipping_val, threshold_value = setup_tile_filtering(signal_array[0, :, :])
-    mp_tile_processor = MpTileProcessor(workers_queue, mp_3d_filter_queue)
-    prev_lock = Lock()
-    processes = []
-
-    # start 2D tile filter (output goes into queue for 3D analysis)
-    for plane_id, plane in enumerate(signal_array):
-        workers_queue.get()
-        lock = Lock()
-        lock.acquire()
-        p = multiprocessing.Process(
-            target=mp_tile_processor.process,
-            args=(
-                plane_id,
-                np.array(plane),
-                prev_lock,
-                lock,
-                clipping_val,
-                threshold_value,
-                soma_diameter,
-                log_sigma_size,
-                n_sds_above_mean_thresh,
-            ),
+        (
+            soma_diameter,
+            max_cluster_size,
+            ball_xy_size,
+            ball_z_size,
+        ) = calculate_parameters_in_pixels(
+            voxel_sizes,
+            soma_diameter,
+            max_cluster_size,
+            ball_xy_size,
+            ball_z_size,
         )
-        prev_lock = lock
-        processes.append(p)
-        p.start()
 
-    processes[-1].join()
-    mp_3d_filter_queue.put((None, None, None))  # Signal the end
-    cells = output_queue.get()
-    bf_process.join()
+        if end_plane == -1:
+            end_plane = len(signal_array)
+        signal_array = signal_array[start_plane:end_plane]
 
-    print(
-        "Detection complete - all planes done in : {}".format(
-            datetime.now() - start_time
+        workers_queue = MultiprocessingQueue(maxsize=n_processes)
+        # WARNING: needs to be AT LEAST ball_z_size
+        self.mp_3d_filter_queue = MultiprocessingQueue(maxsize=ball_z_size)
+        for plane_id in range(n_processes):
+            # place holder for the queue to have the right size on first run
+            workers_queue.put(None)
+
+        if signal_array.ndim != 3:
+            raise IOError("Input data must be 3D")
+
+        setup_params = [
+            signal_array[0, :, :],
+            soma_diameter,
+            ball_xy_size,
+            ball_z_size,
+            ball_overlap_fraction,
+            start_plane,
+        ]
+
+        self.mp3d_filter_output_queue = MultiprocessingQueue()
+        self.mp_3d_filter = Mp3DFilter(
+            self.mp_3d_filter_queue,
+            self.mp3d_filter_output_queue,
+            self.planes_done_queue,
+            soma_diameter,
+            setup_params=setup_params,
+            soma_size_spread_factor=soma_spread_factor,
+            planes_paths_range=signal_array,
+            save_planes=save_planes,
+            plane_directory=plane_directory,
+            start_plane=start_plane,
+            max_cluster_size=max_cluster_size,
+            outlier_keep=outlier_keep,
+            artifact_keep=artifact_keep,
         )
-    )
-    return cells
+
+        # start 3D analysis (waits for planes in queue)
+        self.bf_process = multiprocessing.Process(
+            target=self.mp_3d_filter.process, args=()
+        )
+        self.bf_process.start()  # needs to be started before the loop
+        clipping_val, threshold_value = setup_tile_filtering(
+            signal_array[0, :, :]
+        )
+        mp_tile_processor = MpTileProcessor(
+            workers_queue, self.mp_3d_filter_queue
+        )
+        prev_lock = Lock()
+
+        # start 2D tile filter (output goes into queue for 3D analysis)
+        self.processes = []
+        for plane_id, plane in enumerate(signal_array):
+            workers_queue.get()
+            lock = Lock()
+            lock.acquire()
+            p = multiprocessing.Process(
+                target=mp_tile_processor.process,
+                args=(
+                    plane_id,
+                    np.array(plane),
+                    prev_lock,
+                    lock,
+                    clipping_val,
+                    threshold_value,
+                    soma_diameter,
+                    log_sigma_size,
+                    n_sds_above_mean_thresh,
+                ),
+            )
+            prev_lock = lock
+            self.processes.append(p)
+            p.start()
+
+    def join(self):
+        """
+        Get detection results.
+
+        This will block execution until the results are ready.
+        """
+        self.processes[-1].join()
+        self.mp_3d_filter_queue.put((None, None, None))  # Signal the end
+        cells = self.mp3d_filter_output_queue.get()
+        self.bf_process.join()
+
+        print(
+            "Detection complete - all planes done in : {}".format(
+                datetime.now() - self.start_time
+            )
+        )
+        return cells
+
+
+main = DetectRunner()

--- a/cellfinder_core/detect/filters/volume/multiprocessing.py
+++ b/cellfinder_core/detect/filters/volume/multiprocessing.py
@@ -55,6 +55,15 @@ class Mp3DFilter(object):
         self.setup_params = setup_params
 
     def process(self):
+        """
+        Run the filter.
+
+        After setup this will process items as they are inserted into
+        ``self.data_queue``. Items in ``data_queue`` must be a tuple of
+        (plane_id: int, plane: numpy.ndarray, mask: numpy.ndarray).
+
+        To halt processing pass a tuple of `None`.
+        """
         self.progress_bar = tqdm(
             total=len(self.planes_paths_range), desc="Processing planes"
         )

--- a/cellfinder_core/detect/filters/volume/multiprocessing.py
+++ b/cellfinder_core/detect/filters/volume/multiprocessing.py
@@ -21,6 +21,7 @@ class Mp3DFilter(object):
         self,
         data_queue,
         output_queue,
+        planes_done_queue,
         soma_diameter,
         soma_size_spread_factor=1.4,
         setup_params=None,
@@ -34,6 +35,7 @@ class Mp3DFilter(object):
     ):
         self.data_queue = data_queue
         self.output_queue = output_queue
+        self.planes_done_queue = planes_done_queue
         self.soma_diameter = soma_diameter
         self.soma_size_spread_factor = soma_size_spread_factor
         self.progress_bar = None
@@ -98,9 +100,10 @@ class Mp3DFilter(object):
                     " (out of bounds)"
                 )
 
-            self.z += 1
+            self.planes_done_queue.put(self.z)
             if self.progress_bar is not None:
                 self.progress_bar.update()
+            self.z += 1
 
     def save_plane(self, plane):
         plane_name = f"plane_{str(self.z).zfill(4)}.tif"

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -6,6 +6,7 @@ import imlib.IO.cells as cell_io
 import pytest
 
 from cellfinder_core.main import main
+from cellfinder_core.detect import DetectRunner
 from cellfinder_core.tools.IO import read_with_dask
 
 data_dir = (

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 from math import isclose
 
 import imlib.IO.cells as cell_io
@@ -7,9 +8,15 @@ import pytest
 from cellfinder_core.main import main
 from cellfinder_core.tools.IO import read_with_dask
 
-data_dir = os.path.join(
-    os.getcwd(), "tests", "data", "integration", "detection"
-)
+data_dir = (
+    pathlib.Path(__file__)
+    / ".."
+    / ".."
+    / ".."
+    / "data"
+    / "integration"
+    / "detection"
+).resolve()
 signal_data_path = os.path.join(data_dir, "crop_planes", "ch0")
 background_data_path = os.path.join(data_dir, "crop_planes", "ch1")
 cells_validation_xml = os.path.join(data_dir, "cell_classification.xml")


### PR DESCRIPTION
This PR refactors code to allow the progress of the detection stage to be queried externally. This is needed to drive GUI progress bars in `cellfinder-napari`.

The main change is converting `cellfinder_core.main()` and `cellfinder_core.detect.detect.main()` to classes that can still be run once (the `main()` functions still exist as before). These classes also have `run()` methods to run the code without blocking, and `join()` methods to block and get the results. In between calling these two methods the progress can be queried using code like:

```python
planes_done = []
while len(planes_done) < len(detect_runner.n_planes):
    planes_done.append(detect_runner.planes_done_queue.get(block=True))
    # Call some code here to update an external progress bar
```

This should be extended to the `classify` step too, but to keep this PR short(ish!) I thought I could leave that until after this one has been reviewed and an API settled on.