### PR TITLE
Add Python 3.10 to tox environment list

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39}
+envlist = py{37,38,39,310}
 isolated_build = true
 
 [gh-actions]
@@ -8,6 +8,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 commands = python -m pytest -v --color=yes --cov --cov-report=xml


### PR DESCRIPTION
Even though https://github.com/brainglobe/cellfinder-core/pull/43 technically added support for 3.10, no tests were running on GH actions because I forgot to add Python 3.10 to the tox configuration. This fixes that.