### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Python version support
+Support for installing and running on Python 3.10 has been added. Support for
+Python 3.7 has been dropped.
+
 ### Added
-- Support for installing and running on Python 3.10
 - Re-worked the way processes are created during the detection stage to remove
   ~20 seconds of overhead when running cell detection.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39,310}
+envlist = py{38,39,310}
 isolated_build = true
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
As per https://github.com/brainglobe/bg-gitbook/pull/5, this drops Python 3.7 support. This only removes support for testing. For package wheel building I intend to drop the support in https://github.com/brainglobe/cellfinder-core/pull/41.