### PR TITLE
Improve ball filter cython code

### DIFF
--- a/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
@@ -22,6 +22,7 @@ cdef class BallFilter:
     cdef:
         uint THRESHOLD_VALUE, SOMA_CENTRE_VALUE
         uint ball_xy_size, ball_z_size, tile_step_width, tile_step_height
+        uint middle_z_idx
         int __current_z
         double overlap_fraction, overlap_threshold
 
@@ -62,7 +63,7 @@ cdef class BallFilter:
         # Stores the current planes that are being filtered
         self.volume = np.empty((layer_width, layer_height, ball_z_size), dtype=np.uint16)
         # Index of the middle plane in the volume
-        self.middle_z_idx = <uint> cmath.floor(self.volume.shape[2] / 2)
+        self.middle_z_idx = cmath.floor(ball_z_size / 2)
 
         self.good_tiles_mask = np.empty((int(cmath.ceil(layer_width / tile_step_width)),  # TODO: lazy initialisation
                                          int(cmath.ceil(layer_height / tile_step_height)),
@@ -72,7 +73,7 @@ cdef class BallFilter:
     @property
     def ready(self):
         """
-        Return `True` if there are enough layers appended to filter with.
+        Return `True` if enough layers have been appended to run the filter.
         """
         return self.__current_z == self.ball_z_size - 1
 

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
@@ -21,7 +21,7 @@ cdef class BallFilter:
 
     cdef:
         uint THRESHOLD_VALUE, SOMA_CENTRE_VALUE
-        uint ball_xy_size, tile_step_width, tile_step_height
+        uint ball_xy_size, ball_z_size, tile_step_width, tile_step_height
         int __current_z
         double overlap_fraction, overlap_threshold
 

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
@@ -101,7 +101,8 @@ cdef class BallFilter:
         """
         Get the plane in the middle of self.volume.
         """
-        return np.array(self.volume[:, :, self.middle_z_idx], dtype=np.uint16)
+        cdef uint z = self.middle_z_idx
+        return np.array(self.volume[:, :, z], dtype=np.uint16)
 
     @cython.initializedcheck(False)
     @cython.cdivision(True)
@@ -110,6 +111,7 @@ cdef class BallFilter:
         cdef uint ball_centre_x, ball_centre_y
         cdef uint ball_radius = self.ball_xy_size // 2
         cdef ushort[:,:,:] cube
+        cdef uint middle_z = self.middle_z_idx
 
         cdef uint max_width, max_height
         tile_mask_covered_img_width = self.good_tiles_mask.shape[0] * self.tile_step_width
@@ -124,7 +126,7 @@ cdef class BallFilter:
                 if self.__is_tile_to_check(ball_centre_x, ball_centre_y):
                     cube = self.volume[x:x + self.kernel.shape[0], y:y + self.kernel.shape[1], :]
                     if self.__cube_overlaps(cube):
-                        self.volume[ball_centre_x, ball_centre_y, self.middle_z_idx] = self.SOMA_CENTRE_VALUE
+                        self.volume[ball_centre_x, ball_centre_y, middle_z] = self.SOMA_CENTRE_VALUE
 
     @cython.initializedcheck(False)
     @cython.cdivision(True)
@@ -156,6 +158,8 @@ cdef class BallFilter:
     @cython.boundscheck(False)
     cdef __is_tile_to_check(self, uint x, uint y):  # Highly optimised because most time critical
         cdef uint x_in_mask, y_in_mask, middle_plane_idx
+        cdef uint middle_z = self.middle_z_idx
+
         x_in_mask = x // self.tile_step_width  # TEST: test bounds (-1 range)
         y_in_mask = y // self.tile_step_height  # TEST: test bounds (-1 range)
-        return <bint> self.good_tiles_mask[x_in_mask, y_in_mask, self.middle_z_idx]
+        return <bint> self.good_tiles_mask[x_in_mask, y_in_mask, middle_z]

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
@@ -68,6 +68,8 @@ cdef class BallFilter:
         self.good_tiles_mask = np.empty((int(cmath.ceil(layer_width / tile_step_width)),  # TODO: lazy initialisation
                                          int(cmath.ceil(layer_height / tile_step_height)),
                                          ball_z_size), dtype=np.uint8)
+        # Stores the z-index in volume at which new layers are inserted when
+        # append() is called
         self.__current_z = -1
 
     @property

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
@@ -82,8 +82,8 @@ cdef class BallFilter:
         if not self.ready:
             self.__current_z += 1
         else:
-            self.volume = np.roll(self.volume, self.volume.shape[2] - 1, axis=2)  # WARNING: not in place
-            self.good_tiles_mask = np.roll(self.good_tiles_mask, self.good_tiles_mask.shape[2] - 1, axis=2)
+            self.volume = np.roll(self.volume, -1, axis=2)  # WARNING: not in place
+            self.good_tiles_mask = np.roll(self.good_tiles_mask, -1, axis=2)
         self.volume[:, :, self.__current_z] = layer[:,:]
         self.good_tiles_mask[:, :, self.__current_z] = mask[:,:]
 

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
@@ -74,7 +74,7 @@ cdef class BallFilter:
         """
         Return `True` if there are enough layers appended to filter with.
         """
-        return self.__current_z == self.volume.shape[2] - 1
+        return self.__current_z == self.ball_z_size - 1
 
     cpdef append(self, ushort[:,:] layer, unsigned char[:,:] mask):
         """
@@ -143,7 +143,7 @@ cdef class BallFilter:
 
         cdef uint x, y, z
         for z in range(cube.shape[2]):  # TODO: OPTIMISE: step from middle to outer boundaries to check more data first
-            if z == cmath.floor(self.volume.shape[2] / 2) + 1 and current_overlap_value < self.overlap_threshold * 0.4:  # FIXME: do not hard code value
+            if z == cmath.floor(self.ball_z_size / 2) + 1 and current_overlap_value < self.overlap_threshold * 0.4:  # FIXME: do not hard code value
                 return False  # DEBUG: optimisation attempt
             for y in range(cube.shape[1]):
                 for x in range(cube.shape[0]):

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.pyx
@@ -31,8 +31,10 @@ cdef class BallFilter:
         unsigned char[:,:,:] good_tiles_mask
 
 
-    def __init__(self, layer_width, layer_height, ball_xy_size, ball_z_size, overlap_fraction=0.8,
-                 tile_step_width=None, tile_step_height=None, threshold_value=None, soma_centre_value=None):
+    def __init__(self, layer_width, layer_height,
+                 ball_xy_size, ball_z_size, overlap_fraction=0.8,
+                 tile_step_width=None, tile_step_height=None,
+                 threshold_value=None, soma_centre_value=None):
         self.ball_xy_size = ball_xy_size
         self.overlap_fraction = overlap_fraction
         self.tile_step_width = tile_step_width


### PR DESCRIPTION
As I was going through trying to understand how the ball filter works, I made a few adjustments to make the code more understandable (in my opinion):

- Reflow the __init__ signature so the lines aren't too long
- Save the `ball_z_size` as an attribute, and re-use this throughout the class to replace incoistently named variables that store the same thing
- Save the `middle_z_idx` as an attribute to avoid computing it at several points in the class
- Add some more comments throughout.