### PR TITLE
Split synchronous/asynchronous parts of TileProcessor

### DIFF
--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -136,7 +136,15 @@ def main(
     clipping_val, threshold_value = setup_tile_filtering(signal_array[0, :, :])
 
     # Create 2D analysis filter
-    mp_tile_processor = MpTileProcessor(workers_queue, mp_3d_filter_queue)
+    mp_tile_processor = MpTileProcessor(
+        workers_queue,
+        mp_3d_filter_queue,
+        clipping_val,
+        threshold_value,
+        soma_diameter,
+        log_sigma_size,
+        n_sds_above_mean_thresh,
+    )
     prev_lock = Lock()
 
     # start 2D tile filter (output goes into queue for 3D analysis)
@@ -153,11 +161,6 @@ def main(
                 np.array(plane),
                 prev_lock,
                 lock,
-                clipping_val,
-                threshold_value,
-                soma_diameter,
-                log_sigma_size,
-                n_sds_above_mean_thresh,
             ),
         )
         prev_lock = lock

--- a/src/cellfinder_core/detect/filters/plane/multiprocessing.py
+++ b/src/cellfinder_core/detect/filters/plane/multiprocessing.py
@@ -1,6 +1,7 @@
 import multiprocessing
 from dataclasses import dataclass
 from multiprocessing.synchronize import Lock as LockBase
+from typing import Optional
 
 import numpy as np
 
@@ -46,7 +47,7 @@ class MpTileProcessor:
         self,
         plane_id: int,
         plane: np.ndarray,
-        previous_lock: LockBase,
+        previous_lock: Optional[LockBase],
         self_lock: LockBase,
     ):
         """
@@ -57,11 +58,13 @@ class MpTileProcessor:
         self_lock :
             Lock for the current tile.
         """
+        self_lock.acquire()
         tile_mask = self.get_tile_mask(plane)
 
         # Wait for previous plane to be done
-        previous_lock.acquire()
-        previous_lock.release()
+        if previous_lock is not None:
+            previous_lock.acquire()
+            previous_lock.release()
 
         self.ball_filter_q.put((plane_id, plane, tile_mask))
         self.thread_q.put(plane_id)


### PR DESCRIPTION
This
- splits the syncronous part of `TileProcessor` into a new method called `get_tile_mask`
- Turns `TileProcessor` into a dataclass
- Adds the confiuration parameters as attributes of `TileProcessor`
- Adds some more typing

These changes will make it a lot easier to simplify the process handling code in the future.