### PR TITLE
Improve Process handling during detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for installing and running on Python 3.10
+- Re-worked the way processes are created during the detection stage to remove
+  ~20 seconds of overhead when running cell detection.
+
+### Bug fixes
+- Fixed macOS issues where cellfinder could hang during the detection stage.

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -5,9 +5,7 @@ from typing import Callable
 import numpy as np
 from imlib.general.system import get_num_processes
 
-from cellfinder_core.detect.filters.plane import (
-    TileProcessor,
-)
+from cellfinder_core.detect.filters.plane import TileProcessor
 from cellfinder_core.detect.filters.setup_filters import setup_tile_filtering
 from cellfinder_core.detect.filters.volume.volume_filter import VolumeFilter
 
@@ -130,10 +128,8 @@ def main(
     # asyncronous results
     async_results = []
     for id, plane in enumerate(signal_array):
-        (res,) = (
-            worker_pool.apply_async(
-                mp_tile_processor.get_tile_mask, args=(np.array(plane),)
-            ),
+        res = worker_pool.apply_async(
+            mp_tile_processor.get_tile_mask, args=(np.array(plane),)
         )
         async_results.append(res)
 

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -5,11 +5,11 @@ from typing import Callable
 import numpy as np
 from imlib.general.system import get_num_processes
 
-from cellfinder_core.detect.filters.plane.multiprocessing import (
-    MpTileProcessor,
+from cellfinder_core.detect.filters.plane import (
+    TileProcessor,
 )
 from cellfinder_core.detect.filters.setup_filters import setup_tile_filtering
-from cellfinder_core.detect.filters.volume.multiprocessing import Mp3DFilter
+from cellfinder_core.detect.filters.volume.volume_filter import VolumeFilter
 
 
 def calculate_parameters_in_pixels(
@@ -100,7 +100,7 @@ def main(
     ]
 
     # Create 3D analysis filter
-    mp_3d_filter = Mp3DFilter(
+    mp_3d_filter = VolumeFilter(
         soma_diameter,
         setup_params=setup_params,
         soma_size_spread_factor=soma_spread_factor,
@@ -115,7 +115,7 @@ def main(
 
     clipping_val, threshold_value = setup_tile_filtering(signal_array[0, :, :])
     # Create 2D analysis filter
-    mp_tile_processor = MpTileProcessor(
+    mp_tile_processor = TileProcessor(
         clipping_val,
         threshold_value,
         soma_diameter,

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -101,7 +101,7 @@ def main(
 
     # Create 3D analysis filter
     mp_3d_filter = VolumeFilter(
-        soma_diameter,
+        soma_diameter=soma_diameter,
         setup_params=setup_params,
         soma_size_spread_factor=soma_spread_factor,
         planes_paths_range=signal_array,

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -136,7 +136,15 @@ def main(
     clipping_val, threshold_value = setup_tile_filtering(signal_array[0, :, :])
 
     # Create 2D analysis filter
-    mp_tile_processor = MpTileProcessor(workers_queue, mp_3d_filter_queue)
+    mp_tile_processor = MpTileProcessor(
+        workers_queue,
+        mp_3d_filter_queue,
+        clipping_val,
+        threshold_value,
+        soma_diameter,
+        log_sigma_size,
+        n_sds_above_mean_thresh,
+    )
     prev_lock = Lock()
 
     # start 2D tile filter (output goes into queue for 3D analysis)
@@ -153,11 +161,6 @@ def main(
                 np.array(plane),
                 prev_lock,
                 lock,
-                clipping_val,
-                threshold_value,
-                soma_diameter,
-                log_sigma_size,
-                n_sds_above_mean_thresh,
             ),
         )
         prev_lock = lock

--- a/src/cellfinder_core/detect/filters/plane/__init__.py
+++ b/src/cellfinder_core/detect/filters/plane/__init__.py
@@ -1,0 +1,1 @@
+from .plane_filter import TileProcessor

--- a/src/cellfinder_core/detect/filters/plane/multiprocessing.py
+++ b/src/cellfinder_core/detect/filters/plane/multiprocessing.py
@@ -1,6 +1,7 @@
 import multiprocessing
 from dataclasses import dataclass
 from multiprocessing.synchronize import Lock as LockBase
+from typing import Optional
 
 import numpy as np
 
@@ -46,7 +47,7 @@ class MpTileProcessor:
         self,
         plane_id: int,
         plane: np.ndarray,
-        previous_lock: LockBase,
+        previous_lock: Optional[LockBase],
         self_lock: LockBase,
     ):
         """
@@ -57,11 +58,13 @@ class MpTileProcessor:
         self_lock :
             Lock for the current tile.
         """
+        self_lock.acquire()
         tile_mask = self.get_tile_mask(plane)
 
         # Wait for previous plane to be done
-        previous_lock.acquire()
-        previous_lock.release()
+        if previous_lock is not None:
+            previous_lock.acquire()
+            previous_lock.release()
 
         self.ball_filter_q.put((plane_id, plane, tile_mask))
         self.thread_q.put(plane_id)

--- a/src/cellfinder_core/detect/filters/plane/multiprocessing.py
+++ b/src/cellfinder_core/detect/filters/plane/multiprocessing.py
@@ -1,7 +1,5 @@
-import multiprocessing
 from dataclasses import dataclass
-from multiprocessing.synchronize import Lock as LockBase
-from typing import Optional
+from typing import Tuple
 
 import numpy as np
 
@@ -11,15 +9,18 @@ from cellfinder_core.detect.filters.plane.tile_walker import TileWalker
 
 @dataclass
 class MpTileProcessor:
-    thread_q: multiprocessing.Queue
-    ball_filter_q: multiprocessing.Queue
     clipping_value: float
     threshold_value: float
     soma_diameter: float
     log_sigma_size: float
     n_sds_above_mean_thresh: float
 
-    def get_tile_mask(self, plane: np.ndarray):
+    def get_tile_mask(
+        self, plane: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Warning: this modifies ``plane`` in place.
+        """
         laplace_gaussian_sigma = self.log_sigma_size * self.soma_diameter
         plane = plane.T
         np.clip(plane, 0, self.clipping_value, out=plane)
@@ -41,31 +42,4 @@ class MpTileProcessor:
         plane[
             thresholded_img > avg + self.n_sds_above_mean_thresh * sd
         ] = self.threshold_value
-        return walker.good_tiles_mask.astype(np.uint8)
-
-    def process(
-        self,
-        plane_id: int,
-        plane: np.ndarray,
-        previous_lock: Optional[LockBase],
-        self_lock: LockBase,
-    ):
-        """
-        Parameters
-        ----------
-        previous_lock :
-            Lock for the previous tile in the processing queue.
-        self_lock :
-            Lock for the current tile.
-        """
-        self_lock.acquire()
-        tile_mask = self.get_tile_mask(plane)
-
-        # Wait for previous plane to be done
-        if previous_lock is not None:
-            previous_lock.acquire()
-            previous_lock.release()
-
-        self.ball_filter_q.put((plane_id, plane, tile_mask))
-        self.thread_q.put(plane_id)
-        self_lock.release()
+        return plane, walker.good_tiles_mask.astype(np.uint8)

--- a/src/cellfinder_core/detect/filters/plane/plane_filter.py
+++ b/src/cellfinder_core/detect/filters/plane/plane_filter.py
@@ -8,7 +8,7 @@ from cellfinder_core.detect.filters.plane.tile_walker import TileWalker
 
 
 @dataclass
-class MpTileProcessor:
+class TileProcessor:
     clipping_value: float
     threshold_value: float
     soma_diameter: float

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -2,7 +2,7 @@ import logging
 import math
 import os
 from multiprocessing.pool import AsyncResult
-from typing import Callable, List, Sequence, Tuple
+from typing import Callable, List, Sequence
 
 import numpy as np
 from imlib.cells.cells import Cell
@@ -25,7 +25,7 @@ class VolumeFilter(object):
         *,
         soma_diameter: float,
         soma_size_spread_factor: float = 1.4,
-        setup_params: Tuple,
+        setup_params: Sequence,
         planes_paths_range: Sequence,
         save_planes: bool = False,
         plane_directory: str = None,

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -19,7 +19,7 @@ from cellfinder_core.detect.filters.volume.structure_splitting import (
 )
 
 
-class Mp3DFilter(object):
+class VolumeFilter(object):
     def __init__(
         self,
         soma_diameter,


### PR DESCRIPTION
This PR hugely simplifies how multiprocessing is done during detection. Instead of manually handling individual `Process`es, a `Pool()` of available threads is created, and the 2D detection jobs asyncronously submitted to that worker pool. After submitting all those jobs, the 3D cell detection runs in the main thread, waiting for the outputs of the 2D analysis in order.

This significantly reduces the overhead of process management. Running cellfinder using the test data included goes from ~30s to ~2s for me locally. This speedup will be less dramatic on larger datasets, but not insignificant. On a ~10GB dataset the speedup is from ~2m05s to ~1m50s for me locally. The CI now runs noticably faster too, from ~15min before to ~10min now.

Reducing the code complexity also removes places where things could go wrong, which I think solves a few issues listed below:

Fixes https://github.com/brainglobe/cellfinder-core/issues/38 (by removing the relevant code for that issue)
Probably also fixes https://github.com/brainglobe/cellfinder-core/issues/27
Probably also fixes https://github.com/brainglobe/cellfinder-core/issues/17