### PR TITLE
Don't read all planes into memory at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,6 @@ venv.bak/
 
 pip-wheel-metadata/
 
+mprofile*.dat
+
 *.DS_Store

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,12 @@
+# Benchmarks
+`detect_and_classify.py` contains a simple script that runs
+detection and classification with the small test dataset.
+
+## Memory
+[memory_profiler](https://github.com/pythonprofilers/memory_profiler)
+can be used to profile memory useage. Install, and then run
+`mprof run --include-children --multiprocess detect_and_classify.py`. It is **very**
+important to use these two flags to capture memory useage by the additional
+processes that cellfiner_core uses.
+
+To show the results of the latest profile run, run `mprof plot`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -6,7 +6,7 @@ detection and classification with the small test dataset.
 [memory_profiler](https://github.com/pythonprofilers/memory_profiler)
 can be used to profile memory useage. Install, and then run
 `mprof run --include-children --multiprocess detect_and_classify.py`. It is **very**
-important to use these two flags to capture memory useage by the additional
-processes that cellfiner_core uses.
+important to use these two flags to capture memory usage by the additional
+processes that cellfinder_core uses.
 
 To show the results of the latest profile run, run `mprof plot`.

--- a/benchmarks/detect_and_classify.py
+++ b/benchmarks/detect_and_classify.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import dask.array as da
+
+from cellfinder_core.main import main
+from cellfinder_core.tools.IO import read_with_dask
+
+data_dir = (
+    Path(__file__).parent
+    / ".."
+    / "tests"
+    / "data"
+    / "integration"
+    / "detection"
+).resolve()
+signal_data_path = data_dir / "crop_planes" / "ch0"
+background_data_path = data_dir / "crop_planes" / "ch1"
+
+voxel_sizes = [5, 2, 2]
+
+# Read data
+signal_array = read_with_dask(str(signal_data_path))
+background_array = read_with_dask(str(background_data_path))
+
+# Artificially increase size of the test data
+repeats = 5
+signal_array = da.repeat(signal_array, repeats=repeats, axis=0)
+background_array = da.repeat(background_array, repeats=repeats, axis=0)
+
+if __name__ == "__main__":
+    # Run detection & classification
+    main(signal_array, background_array, voxel_sizes, n_free_cpus=0)

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -141,9 +141,7 @@ def main(
         # Start 3D filter
         # This runs in the main thread, and blocks until the all the 2D and
         # then 3D filtering has finished
-        cells = mp_3d_filter.process(
-            async_results, n_planes=len(signal_array), callback=callback
-        )
+        cells = mp_3d_filter.process(async_results, callback=callback)
 
     print(
         "Detection complete - all planes done in : {}".format(

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -140,7 +140,9 @@ def main(
         # Start 3D filter
         # This runs in the main thread, and blocks until the all the 2D and
         # then 3D filtering has finished
-        cells = mp_3d_filter.process(async_results, callback=callback)
+        cells = mp_3d_filter.process(
+            async_results, n_planes=len(signal_array), callback=callback
+        )
 
     print(
         "Detection complete - all planes done in : {}".format(

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -1,5 +1,5 @@
+import multiprocessing
 from datetime import datetime
-from multiprocessing.pool import Pool
 from queue import Queue
 from typing import Callable
 
@@ -121,7 +121,8 @@ def main(
         n_sds_above_mean_thresh,
     )
 
-    with Pool(n_processes) as worker_pool:
+    mp_ctx = multiprocessing.get_context("spawn")
+    with mp_ctx.Pool(n_processes) as worker_pool:
         # Start 2D filter
         # Submits each plane to the worker pool, and sets up a queue of
         # asyncronous results

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from multiprocessing.pool import Pool
+from queue import Queue
 from typing import Callable
 
-import numpy as np
 from imlib.general.system import get_num_processes
 
 from cellfinder_core.detect.filters.plane import TileProcessor
@@ -123,20 +123,24 @@ def main(
 
     with Pool(n_processes) as worker_pool:
         # Start 2D filter
-        # Submits each plane to the worker pool, and sets up a list of
+        # Submits each plane to the worker pool, and sets up a queue of
         # asyncronous results
-        async_results = []
-        for id, plane in enumerate(signal_array):
+        async_results: Queue = Queue()
+
+        # NOTE: Need to make sure every plane isn't read into memory at this
+        # stage, as all of these jobs are submitted immediately to the pool.
+        # *plane* is a dask array, so as long as it isn't forced into memory
+        # (e.g. using np.array(plane)) here then there shouldn't be an issue
+        for plane in signal_array:
             res = worker_pool.apply_async(
-                mp_tile_processor.get_tile_mask, args=(np.array(plane),)
+                mp_tile_processor.get_tile_mask, args=(plane,)
             )
-            async_results.append(res)
+            async_results.put(res)
 
         # Start 3D filter
-        # This runs in the main thread
-        cells = mp_3d_filter.process(
-            async_results, signal_array, callback=callback
-        )
+        # This runs in the main thread, and blocks until the all the 2D and
+        # then 3D filtering has finished
+        cells = mp_3d_filter.process(async_results, callback=callback)
 
     print(
         "Detection complete - all planes done in : {}".format(

--- a/src/cellfinder_core/detect/filters/plane/plane_filter.py
+++ b/src/cellfinder_core/detect/filters/plane/plane_filter.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
+import dask.array as da
 import numpy as np
 
 from cellfinder_core.detect.filters.plane.classical_filter import enhance_peaks
@@ -15,15 +16,25 @@ class TileProcessor:
     log_sigma_size: float
     n_sds_above_mean_thresh: float
 
-    def get_tile_mask(
-        self, plane: np.ndarray
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    def get_tile_mask(self, plane: da.array) -> Tuple[np.ndarray, np.ndarray]:
         """
-        Warning: this modifies ``plane`` in place.
+        Parameters
+        ----------
+        plane :
+            Input plane.
+
+        Returns
+        -------
+        plane :
+            Modified plane.
+        mask :
+            Good tiles mask.
         """
         laplace_gaussian_sigma = self.log_sigma_size * self.soma_diameter
         plane = plane.T
-        np.clip(plane, 0, self.clipping_value, out=plane)
+        plane = np.clip(plane, 0, self.clipping_value)
+        # Read plane from a dask array into memory as a numpy array
+        plane = np.array(plane)
 
         walker = TileWalker(plane, self.soma_diameter)
 
@@ -35,11 +46,9 @@ class TileProcessor:
             gaussian_sigma=laplace_gaussian_sigma,
         )
 
-        # threshold
         avg = thresholded_img.ravel().mean()
         sd = thresholded_img.ravel().std()
+        threshold = avg + self.n_sds_above_mean_thresh * sd
 
-        plane[
-            thresholded_img > avg + self.n_sds_above_mean_thresh * sd
-        ] = self.threshold_value
+        plane[thresholded_img > threshold] = self.threshold_value
         return plane, walker.good_tiles_mask.astype(np.uint8)

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -60,12 +60,14 @@ class VolumeFilter(object):
     def process(
         self,
         async_results: Queue,
+        n_planes: int,
+        *,
         callback: Callable[[int], None],
     ):
         progress_bar = tqdm(
             total=len(self.planes_paths_range), desc="Processing planes"
         )
-        while not async_results.empty():
+        for _ in range(n_planes):
             # Get result from the queue.
             #
             # It is important to remove the result from the queue here

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -59,21 +59,20 @@ class VolumeFilter(object):
 
     def process(
         self,
-        async_results: Queue,
-        n_planes: int,
+        async_result_queue: Queue,
         *,
         callback: Callable[[int], None],
     ):
         progress_bar = tqdm(
             total=len(self.planes_paths_range), desc="Processing planes"
         )
-        for _ in range(n_planes):
+        while not async_result_queue.empty():
             # Get result from the queue.
             #
             # It is important to remove the result from the queue here
             # to free up memory once this plane has been processed by
             # the 3D filter here
-            result = async_results.get()
+            result = async_result_queue.get()
             # .get() blocks until the result is available
             plane, mask = result.get()
 

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -1,10 +1,9 @@
 import logging
 import math
 import os
-from multiprocessing.pool import AsyncResult
-from typing import Callable, List, Sequence
+from queue import Queue
+from typing import Callable, Sequence
 
-import numpy as np
 from imlib.cells.cells import Cell
 from tifffile import tifffile
 from tqdm import tqdm
@@ -60,37 +59,42 @@ class VolumeFilter(object):
 
     def process(
         self,
-        async_results: List[AsyncResult],
-        signal_array: np.ndarray,
+        async_results: Queue,
         callback: Callable[[int], None],
     ):
         progress_bar = tqdm(
             total=len(self.planes_paths_range), desc="Processing planes"
         )
+        while not async_results.empty():
+            # Get result from the queue.
+            #
+            # It is important to remove the result from the queue here
+            # to free up memory once this plane has been processed by
+            # the 3D filter here
+            result = async_results.get()
+            # .get() blocks until the result is available
+            plane, mask = result.get()
 
-        for plane_id, res in enumerate(async_results):
-            plane, mask = res.get()
-            logging.debug(f"Plane {plane_id} received for 3D filtering")
-            print(f"Plane {plane_id} received for 3D filtering")
+            logging.debug(f"Plane {self.z} received for 3D filtering")
+            print(f"Plane {self.z} received for 3D filtering")
 
-            logging.debug(f"Adding plane {plane_id} for 3D filtering")
+            logging.debug(f"Adding plane {self.z} for 3D filtering")
             self.ball_filter.append(plane, mask)
 
             if self.ball_filter.ready:
-                logging.debug(f"Ball filtering plane {plane_id}")
+                logging.debug(f"Ball filtering plane {self.z}")
                 self.ball_filter.walk()
 
                 middle_plane = self.ball_filter.get_middle_plane()
                 if self.save_planes:
                     self.save_plane(middle_plane)
 
-                logging.debug(f"Detecting structures for plane {plane_id}")
+                logging.debug(f"Detecting structures for plane {self.z}")
                 self.cell_detector.process(middle_plane)
 
-                logging.debug(f"Structures done for plane {plane_id}")
+                logging.debug(f"Structures done for plane {self.z}")
                 logging.debug(
-                    f"Skipping plane {plane_id} for 3D filter"
-                    " (out of bounds)"
+                    f"Skipping plane {self.z} for 3D filter" " (out of bounds)"
                 )
 
             callback(self.z)


### PR DESCRIPTION
This fixes https://github.com/brainglobe/cellfinder-core/issues/52 - the issue there was that all planes were being read into memory before the 2D processing start, instead of being read into memory when they were being processed. This PR fixes that by storing the planes in a `Queue`, and removing them from that `Queue` when the 3D filtering is done.