### PR TITLE
Revert changes to prep function arguments

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run cellfinder tests
         run: |
-          python -m pytest -v
+          python -m pytest --color=yes -v
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run cellfinder tests
         run: |
-          python -m pytest tests/tests/test_integration/test_detection.py
+          python -m pytest -v
 
   build_sdist:
     name: Build source distribution

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ signal_array = tifffile.imread("/path/to/signal_image.tif")
 background_array = tifffile.imread("/path/to/background_image.tif")
 voxel_sizes = [5, 2, 2] # in microns
 
+home = Path.home()
+install_path = home / ".cellfinder" # default
+
 start_plane=0
 end_plane=-1
 trained_model=None
@@ -169,7 +172,7 @@ cube_depth=20
 network_depth="50"
 
 model_weights = prep_classification(
-    trained_model, model_weights, model, n_free_cpus
+    trained_model, model_weights, install_path, model, n_free_cpus
 )
 
 cell_candidates = detect.main(
@@ -230,9 +233,13 @@ yaml_files = [Path("/path/to/training_yml.yml)]
 # where to save the output
 output_directory = Path("/path/to/saved_training_data")
 
+home = Path.home()
+install_path = home / ".cellfinder"  # default
+
 run_training(
     output_directory,
     yaml_files,
+    install_path=install_path,
     learning_rate=0.0001,
     continue_training=True, # by default use supplied model
     test_fraction=0.1,

--- a/src/cellfinder_core/main.py
+++ b/src/cellfinder_core/main.py
@@ -82,8 +82,9 @@ def main(
     if detect_finished_callback is not None:
         detect_finished_callback(points)
 
+    install_path = None
     model_weights = prep.prep_classification(
-        trained_model, model_weights, model, n_free_cpus
+        trained_model, model_weights, install_path, model, n_free_cpus
     )
     if len(points) > 0:
         logging.info("Running classification")

--- a/src/cellfinder_core/tools/prep.py
+++ b/src/cellfinder_core/tools/prep.py
@@ -23,14 +23,14 @@ DEFAULT_INSTALL_PATH = home / ".cellfinder"
 def prep_classification(
     trained_model: Optional[os.PathLike],
     model_weights: Optional[os.PathLike],
+    install_path: Optional[os.PathLike],
     model_name: str,
     n_free_cpus: int,
-    install_path: os.PathLike = DEFAULT_INSTALL_PATH,
 ) -> Path:
     n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
     prep_tensorflow(n_processes)
     model_weights = prep_models(
-        trained_model, model_weights, model_name, install_path
+        trained_model, model_weights, install_path, model_name
     )
 
     return model_weights
@@ -40,13 +40,13 @@ def prep_training(
     n_free_cpus: int,
     trained_model: Optional[os.PathLike],
     model_weights: Optional[os.PathLike],
+    install_path: Optional[os.PathLike],
     model_name: str,
-    install_path: os.PathLike = DEFAULT_INSTALL_PATH,
 ) -> Path:
     n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
     prep_tensorflow(n_processes)
     model_weights = prep_models(
-        trained_model, model_weights, model_name, install_path=install_path
+        trained_model, model_weights, install_path, model_name
     )
     return model_weights
 
@@ -59,9 +59,10 @@ def prep_tensorflow(max_threads: int) -> None:
 def prep_models(
     trained_model_path: Optional[os.PathLike],
     model_weights_path: Optional[os.PathLike],
+    install_path: Optional[os.PathLike],
     model_name: str,
-    install_path: os.PathLike = DEFAULT_INSTALL_PATH,
 ) -> Path:
+    install_path = install_path or DEFAULT_INSTALL_PATH
     # if no model or weights, set default weights
     if model_weights_path is None:
         logging.debug("No model supplied, so using the default")

--- a/src/cellfinder_core/train/train_yml.py
+++ b/src/cellfinder_core/train/train_yml.py
@@ -335,9 +335,9 @@ def run(
     model_weights = prep_training(
         n_free_cpus,
         trained_model,
+        install_path,
         model_weights,
         model,
-        install_path=install_path,
     )
 
     yaml_contents = parse_yaml(yaml_file)


### PR DESCRIPTION
This partially reverts https://github.com/brainglobe/cellfinder-core/pull/56, which changed the order of arguments and therefore broke `cellfinder`.