### PR TITLE
Use setuptools_scm for versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'cython']
+requires = ['setuptools>=45', "setuptools_scm>=6.2", 'wheel', 'cython']
 build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
+write_to = "src/cellfinder_core/_version.py"
 
 [tool.black]
 target-version = ['py36', 'py37', 'py38']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,37 +1,11 @@
-[bumpversion]
-current_version = 0.3.0
-commit = True
-tag = True
-tag_name = {new_version}
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<rc>\d+))?
-serialize = 
-	{major}.{minor}.{patch}-{release}{rc}
-	{major}.{minor}.{patch}
-
 [options]
-package_dir = 
+package_dir =
 	=src
 packages = find:
 
 [options.packages.find]
 where = src
 
-[bumpversion:part:release]
-optional_value = prod
-first_value = rc
-values = 
-	rc
-	prod
-
-[bumpversion:part:rc]
-
-[bumpversion:file:setup.py]
-search = version="{current_version}"
-replace = version="{new_version}"
-
-[bumpversion:file:src/cellfinder_core/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
 
 [flake8]
 ignore = E203, E231, W503, E722

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ extensions = [
 
 setup(
     name="cellfinder-core",
-    version="0.3.0",
     description="Automated 3D cell detection in large microscopy images",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -67,12 +66,10 @@ setup(
             "pytest-timeout",
             "gitpython",
             "coverage>=5.0.3",
-            "bump2version",
             "pre-commit",
             "flake8",
         ]
     },
-    setup_requires=["cython"],
     python_requires=">=3.7",
     include_package_data=True,
     ext_modules=Cython.Build.cythonize(extensions),

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -1,3 +1,7 @@
-__version__ = "0.3.0"
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"
+
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "unknown version"


### PR DESCRIPTION
This is the modern way to do automatic Python versioning, and removes a lot of the configuration that needs to be done with `bump2version`.

The version is inferred from the git repository checkout state when the package is installed, and then written to a file. This also has the advantage of distinguishing between released and non-released versions of the package, giving unreleased versions a version like '0.3.1.dev21+ge3c2e7a.d20220615'.