### PR TITLE
Add cellfinder_core specific logger

### DIFF
--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -1,3 +1,7 @@
 __version__ = "0.3.0"
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"
+
+import logging
+
+logger = logging.getLogger("cellfinder_core")

--- a/src/cellfinder_core/classify/classify.py
+++ b/src/cellfinder_core/classify/classify.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Callable, Optional
 
 import numpy as np
 from imlib.general.system import get_num_processes
 from tensorflow import keras
 
+from cellfinder_core import logger
 from cellfinder_core.classify.cube_generator import CubeGeneratorFromFile
 from cellfinder_core.classify.tools import get_model
 from cellfinder_core.train.train_yml import models
@@ -50,7 +50,7 @@ def main(
         min_free_cpu_cores=n_free_cpus, n_max_processes=max_workers
     )
 
-    logging.debug("Initialising cube generator")
+    logger.debug("Initialising cube generator")
     inference_generator = CubeGeneratorFromFile(
         points,
         signal_array,
@@ -70,7 +70,7 @@ def main(
         inference=True,
     )
 
-    logging.info("Running inference")
+    logger.info("Running inference")
     predictions = model.predict(
         inference_generator,
         use_multiprocessing=True,

--- a/src/cellfinder_core/classify/tools.py
+++ b/src/cellfinder_core/classify/tools.py
@@ -1,8 +1,7 @@
-import logging
-
 import numpy as np
 import tensorflow as tf
 
+from cellfinder_core import logger
 from cellfinder_core.classify.resnet import build_model
 
 
@@ -31,15 +30,15 @@ def get_model(
 
     """
     if existing_model is not None:
-        logging.debug(f"Loading model: {existing_model}")
+        logger.debug(f"Loading model: {existing_model}")
         return tf.keras.models.load_model(existing_model)
     else:
-        logging.debug(f"Creating a new instance of model: {network_depth}")
+        logger.debug(f"Creating a new instance of model: {network_depth}")
         model = build_model(
             network_depth=network_depth, learning_rate=learning_rate
         )
         if inference or continue_training:
-            logging.debug(
+            logger.debug(
                 f"Setting model weights according to: {model_weights}"
             )
             if model_weights is None:

--- a/src/cellfinder_core/detect/filters/volume/structure_splitting.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_splitting.py
@@ -1,7 +1,6 @@
-import logging
-
 import numpy as np
 
+from cellfinder_core import logger
 from cellfinder_core.detect.filters.volume.ball_filter import BallFilter
 from cellfinder_core.detect.filters.volume.structure_detection import (
     CellDetector,
@@ -107,7 +106,7 @@ def check_centre_in_cuboid(centre, max_coords):
     """
     relative_coords = np.array([centre[k] for k in ("x", "y", "z")])
     if (relative_coords > max_coords).all():
-        logging.info(
+        logger.info(
             'Relative coordinates "{}" exceed maximum volume '
             'dimension of "{}"'.format(relative_coords, max_coords)
         )

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -1,4 +1,3 @@
-import logging
 import math
 import os
 from queue import Queue
@@ -8,6 +7,7 @@ from imlib.cells.cells import Cell
 from tifffile import tifffile
 from tqdm import tqdm
 
+from cellfinder_core import logger
 from cellfinder_core.detect.filters.setup_filters import setup
 from cellfinder_core.detect.filters.volume.structure_detection import (
     get_structure_centre_wrapper,
@@ -76,25 +76,25 @@ class VolumeFilter(object):
             # .get() blocks until the result is available
             plane, mask = result.get()
 
-            logging.debug(f"Plane {self.z} received for 3D filtering")
+            logger.debug(f"Plane {self.z} received for 3D filtering")
             print(f"Plane {self.z} received for 3D filtering")
 
-            logging.debug(f"Adding plane {self.z} for 3D filtering")
+            logger.debug(f"Adding plane {self.z} for 3D filtering")
             self.ball_filter.append(plane, mask)
 
             if self.ball_filter.ready:
-                logging.debug(f"Ball filtering plane {self.z}")
+                logger.debug(f"Ball filtering plane {self.z}")
                 self.ball_filter.walk()
 
                 middle_plane = self.ball_filter.get_middle_plane()
                 if self.save_planes:
                     self.save_plane(middle_plane)
 
-                logging.debug(f"Detecting structures for plane {self.z}")
+                logger.debug(f"Detecting structures for plane {self.z}")
                 self.cell_detector.process(middle_plane)
 
-                logging.debug(f"Structures done for plane {self.z}")
-                logging.debug(
+                logger.debug(f"Structures done for plane {self.z}")
+                logger.debug(
                     f"Skipping plane {self.z} for 3D filter" " (out of bounds)"
                 )
 
@@ -103,7 +103,7 @@ class VolumeFilter(object):
             progress_bar.update()
 
         progress_bar.close()
-        logging.debug("3D filter done")
+        logger.debug("3D filter done")
         return self.get_results()
 
     def save_plane(self, plane):
@@ -112,7 +112,7 @@ class VolumeFilter(object):
         tifffile.imsave(f_path, plane.T)
 
     def get_results(self):
-        logging.info("Splitting cell clusters and writing results")
+        logger.info("Splitting cell clusters and writing results")
 
         max_cell_volume = sphere_volume(
             self.soma_size_spread_factor * self.soma_diameter / 2

--- a/src/cellfinder_core/download/models.py
+++ b/src/cellfinder_core/download/models.py
@@ -1,7 +1,7 @@
-import logging
 import os
 from pathlib import Path
 
+from cellfinder_core import logger
 from cellfinder_core.download.download import download
 
 model_weight_urls = {
@@ -29,7 +29,7 @@ def main(model_name: str, download_path: os.PathLike) -> Path:
     if not model_path.exists():
         model_weight_dir.mkdir(parents=True)
 
-        logging.info(
+        logger.info(
             f"Downloading '{model_name}' model. This may take a little while."
         )
 
@@ -41,8 +41,6 @@ def main(model_name: str, download_path: os.PathLike) -> Path:
         )
 
     else:
-        logging.info(
-            f"Model already exists at {model_path}. Skipping download"
-        )
+        logger.info(f"Model already exists at {model_path}. Skipping download")
 
     return model_path

--- a/src/cellfinder_core/main.py
+++ b/src/cellfinder_core/main.py
@@ -3,10 +3,11 @@ N.B imports are within functions to prevent tensorflow being imported before
 it's warnings are silenced
 """
 
-import logging
 import os
 
 from imlib.general.logging import suppress_specific_logs
+
+from cellfinder_core import logger
 
 tf_suppress_log_messages = [
     "multiprocessing can interact badly with TensorFlow"
@@ -60,7 +61,7 @@ def main(
     from cellfinder_core.detect import detect
     from cellfinder_core.tools import prep
 
-    logging.info("Detecting cell candidates")
+    logger.info("Detecting cell candidates")
 
     points = detect.main(
         signal_array,
@@ -87,7 +88,7 @@ def main(
         trained_model, model_weights, install_path, model, n_free_cpus
     )
     if len(points) > 0:
-        logging.info("Running classification")
+        logger.info("Running classification")
         points = classify.main(
             points,
             signal_array,
@@ -105,9 +106,9 @@ def main(
             callback=classify_callback,
         )
     else:
-        logging.info("No candidates, skipping classification")
+        logger.info("No candidates, skipping classification")
     return points
-    # logging.info("Saving classified cells")
+    # logger.info("Saving classified cells")
     # save_cells(points, classified_points_path)
 
 

--- a/src/cellfinder_core/tools/prep.py
+++ b/src/cellfinder_core/tools/prep.py
@@ -3,7 +3,6 @@ prep
 ==================
 Functions to prepare files and directories needed for other functions
 """
-import logging
 import os
 from pathlib import Path
 from typing import Optional
@@ -12,6 +11,7 @@ from imlib.general.config import get_config_obj
 from imlib.general.system import get_num_processes
 
 import cellfinder_core.tools.tf as tf_tools
+from cellfinder_core import logger
 from cellfinder_core.download import models as model_download
 from cellfinder_core.download.download import amend_cfg
 from cellfinder_core.tools.source_files import source_custom_config_cellfinder
@@ -65,18 +65,18 @@ def prep_models(
     install_path = install_path or DEFAULT_INSTALL_PATH
     # if no model or weights, set default weights
     if model_weights_path is None:
-        logging.debug("No model supplied, so using the default")
+        logger.debug("No model supplied, so using the default")
 
         config_file = source_custom_config_cellfinder()
 
         if not Path(config_file).exists():
-            logging.debug("Custom config does not exist, downloading models")
+            logger.debug("Custom config does not exist, downloading models")
             model_path = model_download.main(model_name, install_path)
             amend_cfg(new_model_path=model_path)
 
         model_weights = get_model_weights(config_file)
         if not model_weights.exists():
-            logging.debug("Model weights do not exist, downloading")
+            logger.debug("Model weights do not exist, downloading")
             model_path = model_download.main(model_name, install_path)
             amend_cfg(new_model_path=model_path)
             model_weights = get_model_weights(config_file)
@@ -86,7 +86,7 @@ def prep_models(
 
 
 def get_model_weights(config_file: os.PathLike) -> Path:
-    logging.debug(f"Reading config file: {config_file}")
+    logger.debug(f"Reading config file: {config_file}")
     config_obj = get_config_obj(config_file)
     model_conf = config_obj["model"]
     model_weights = model_conf["model_path"]

--- a/src/cellfinder_core/tools/tf.py
+++ b/src/cellfinder_core/tools/tf.py
@@ -1,6 +1,6 @@
-import logging
-
 import tensorflow as tf
+
+from cellfinder_core import logger
 
 
 def allow_gpu_memory_growth():
@@ -11,20 +11,20 @@ def allow_gpu_memory_growth():
     """
     gpus = tf.config.experimental.list_physical_devices("GPU")
     if gpus:
-        logging.debug("Allowing GPU memory growth")
+        logger.debug("Allowing GPU memory growth")
         try:
             # Currently, memory growth needs to be the same across GPUs
             for gpu in gpus:
                 tf.config.experimental.set_memory_growth(gpu, True)
             logical_gpus = tf.config.experimental.list_logical_devices("GPU")
-            logging.debug(
+            logger.debug(
                 f"{len(gpus)} physical GPUs, {len(logical_gpus)} logical GPUs"
             )
         except RuntimeError as e:
             # Memory growth must be set before GPUs have been initialized
             print(e)
     else:
-        logging.debug("No GPUs found, using CPU.")
+        logger.debug("No GPUs found, using CPU.")
 
 
 def set_tf_threads(max_threads):
@@ -33,7 +33,7 @@ def set_tf_threads(max_threads):
     :param max_threads: Maximum number of threads to use
     :return:
     """
-    logging.debug(
+    logger.debug(
         f"Setting maximum number of threads for tensorflow "
         f"to: {max_threads}"
     )

--- a/src/cellfinder_core/train/train_yml.py
+++ b/src/cellfinder_core/train/train_yml.py
@@ -8,8 +8,6 @@ N.B imports are within functions to prevent tensorflow being imported before
 it's warnings are silenced
 """
 
-
-import logging
 import os
 from argparse import (
     ArgumentDefaultsHelpFormatter,
@@ -27,6 +25,7 @@ from imlib.IO.yaml import read_yaml_section
 from sklearn.model_selection import train_test_split
 
 import cellfinder_core as program_for_log
+from cellfinder_core import logger
 from cellfinder_core.tools.prep import DEFAULT_INSTALL_PATH
 
 tf_suppress_log_messages = [
@@ -343,7 +342,7 @@ def run(
     yaml_contents = parse_yaml(yaml_file)
 
     tiff_files = get_tiff_files(yaml_contents)
-    logging.info(
+    logger.info(
         f"Found {sum(len(imlist) for imlist in tiff_files)} images "
         f"from {len(yaml_contents)} datasets "
         f"in {len(yaml_file)} yaml files"
@@ -360,7 +359,7 @@ def run(
     signal_train, background_train, labels_train = make_lists(tiff_files)
 
     if test_fraction > 0:
-        logging.info("Splitting data into training and validation datasets")
+        logger.info("Splitting data into training and validation datasets")
         (
             signal_train,
             signal_test,
@@ -375,7 +374,7 @@ def run(
             test_size=test_fraction,
         )
 
-        logging.info(
+        logger.info(
             f"Using {len(signal_train)} images for training and "
             f"{len(signal_test)} images for validation"
         )
@@ -391,7 +390,7 @@ def run(
         base_checkpoint_file_name = "-epoch.{epoch:02d}-loss-{val_loss:.3f}.h5"
 
     else:
-        logging.info("No validation data selected.")
+        logger.info("No validation data selected.")
         validation_generator = None
         base_checkpoint_file_name = "-epoch.{epoch:02d}.h5"
 
@@ -434,7 +433,7 @@ def run(
         csv_logger = CSVLogger(filepath)
         callbacks.append(csv_logger)
 
-    logging.info("Beginning training.")
+    logger.info("Beginning training.")
     model.fit(
         training_generator,
         validation_data=validation_generator,
@@ -444,13 +443,13 @@ def run(
     )
 
     if save_weights:
-        logging.info("Saving model weights")
+        logger.info("Saving model weights")
         model.save_weights(str(output_dir / "model_weights.h5"))
     else:
-        logging.info("Saving model")
+        logger.info("Saving model")
         model.save(output_dir / "model.h5")
 
-    logging.info(
+    logger.info(
         "Finished training, " "Total time taken: %s",
         datetime.now() - start_time,
     )


### PR DESCRIPTION
This adds a logger that is specific to `cellfinder_core`, instead of using the root Python logger. This allows one to customize the `cellfinder-core` logger independently of other log messages, e.g. to show DEBUG messages just from cellfinder-core but not other packages:

```python
import logging
from cellfinder_core import logger

setLevel(logging.DEBUG)
```