### PR TITLE
Error early if image data isn't integer datatype

### DIFF
--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from queue import Queue
 from typing import Callable
 
+import numpy as np
 from imlib.general.system import get_num_processes
 
 from cellfinder_core.detect.filters.plane import TileProcessor
@@ -63,6 +64,11 @@ def main(
         A callback function that is called every time a plane has finished
         being processed. Called with the plane number that has finished.
     """
+    if not np.issubdtype(signal_array, np.integer):
+        raise ValueError(
+            "signal_array must be integer datatype, but has datatype "
+            f"{signal_array.dtype}"
+        )
     n_processes = get_num_processes(min_free_cpu_cores=n_free_cpus)
     start_time = datetime.now()
 

--- a/src/cellfinder_core/tools/tools.py
+++ b/src/cellfinder_core/tools/tools.py
@@ -1,19 +1,18 @@
 from random import getrandbits, uniform
 
+import numpy as np
 from natsort import natsorted
 
 
-def get_max_value(obj_in):
+def get_max_value(obj_in: np.ndarray) -> int:
     """
-    Returns the maximum allowed value for a specific object type.
-    :param obj_in: Object
-    :return int: Maximum value of object type
+    Returns the maximum allowed value for a numpy array of integer data type.
     """
-    # TODO: Generalise, and not rely on parsing a string
-    if obj_in.dtype == "uint8":
-        return 255
+    dtype = obj_in.dtype
+    if np.issubdtype(dtype, np.integer):
+        return np.iinfo(dtype).max
     else:
-        return 2 ** int(str(obj_in.dtype)[-2:]) - 1
+        raise ValueError("obj_in must be a numpy array of integer data type.")
 
 
 def union(a, b):

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -30,13 +30,8 @@ def background_array():
 
 
 # FIXME: This isn't a very good example
-
-
 @pytest.mark.slow
-def test_detection_full():
-
-    signal_array = read_with_dask(signal_data_path)
-    background_array = read_with_dask(background_data_path)
+def test_detection_full(signal_array, background_array):
 
     cells_test = main(
         signal_array,
@@ -99,3 +94,9 @@ def test_callbacks(signal_array, background_array):
     assert ncalls == 1, f"Expected 1 call to callback, got {ncalls}"
     npoints = len(points_found[0])
     assert npoints == 120, f"Expected 120 points, found {npoints}"
+
+
+def test_floating_point_error(signal_array, background_array):
+    signal_array = signal_array.astype(float)
+    with pytest.raises(ValueError, match="signal_array must be integer"):
+        main(signal_array, background_array, voxel_sizes)

--- a/tests/tests/test_unit/test_tools/test_tools_general.py
+++ b/tests/tests/test_unit/test_tools/test_tools_general.py
@@ -22,6 +22,10 @@ def test_get_max_value():
     num = random.randint(0, 100)
     assert 255 == tools.get_max_value(np.array(num, dtype=np.uint8))
     assert 65535 == tools.get_max_value(np.array(num, dtype=np.uint16))
+    with pytest.raises(
+        ValueError, match="must be a numpy array of integer data type"
+    ):
+        tools.get_max_value(np.array(num, dtype=object))
 
 
 def test_union():


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description
This
- Updates `get_max_value` to use more robust code (calling a numpy function) instead of parsing the data type string
- Raises an error early if the data type of the image isn't integer

## References
Fixes https://github.com/brainglobe/cellfinder-core/issues/67

## How has this PR been tested?
I've added a new test for the new error.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
