### PR TITLE
Fix datatype detection

### DIFF
--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -64,7 +64,7 @@ def main(
         A callback function that is called every time a plane has finished
         being processed. Called with the plane number that has finished.
     """
-    if not np.issubdtype(signal_array, np.integer):
+    if not np.issubdtype(signal_array.dtype, np.integer):
         raise ValueError(
             "signal_array must be integer datatype, but has datatype "
             f"{signal_array.dtype}"


### PR DESCRIPTION
For some reason https://github.com/brainglobe/cellfinder-core/pull/68 works on the local tests here in `cellfinder-core`, but when I was trying to run something in `cellfinder-napari` the datatype detection was raising an error. This PR fixes that error.