### PR TITLE
Add macOS arm64 wheel building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ include-package-data = true
 [tool.cibuildwheel]
 build = "cp38-* cp39-* cp310-*"
 
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+
 [tool.pytest.ini_options]
 addopts = "--cov=src/cellfinder_core"
 filterwarnings = [


### PR DESCRIPTION
Tested on the run at https://github.com/brainglobe/cellfinder-core/actions/runs/4103823424/jobs/7078512416, which passed.

Fixes https://github.com/brainglobe/cellfinder-core/issues/51.