### PR TITLE
Use random arrays for memory testing

### DIFF
--- a/benchmarks/detect_and_classify.py
+++ b/benchmarks/detect_and_classify.py
@@ -1,31 +1,22 @@
-from pathlib import Path
-
 import dask.array as da
+import numpy as np
 
 from cellfinder_core.main import main
-from cellfinder_core.tools.IO import read_with_dask
-
-data_dir = (
-    Path(__file__).parent
-    / ".."
-    / "tests"
-    / "data"
-    / "integration"
-    / "detection"
-).resolve()
-signal_data_path = data_dir / "crop_planes" / "ch0"
-background_data_path = data_dir / "crop_planes" / "ch1"
 
 voxel_sizes = [5, 2, 2]
 
-# Read data
-signal_array = read_with_dask(str(signal_data_path))
-background_array = read_with_dask(str(background_data_path))
+# Use random data for signal/background data
+repeats = 2
+shape = (30 * repeats, 510, 667)
 
-# Artificially increase size of the test data
-repeats = 5
-signal_array = da.repeat(signal_array, repeats=repeats, axis=0)
-background_array = da.repeat(background_array, repeats=repeats, axis=0)
+signal_array = da.random.random(shape)
+signal_array = (signal_array * 65535).astype(np.uint16)
+
+background_array = da.random.random(shape)
+background_array = (signal_array * 65535).astype(np.uint16)
+
+array_size_MB = signal_array.nbytes / 1024 / 1024
+print(f"Signal array size = {array_size_MB:.02f} MB")
 
 if __name__ == "__main__":
     # Run detection & classification


### PR DESCRIPTION
It turns out if you increase the size of a dask array using `da.repeat(...)`, dask is clever and doesn't make actual copies of the data. This is great, unless you're running memory benchmarks and *want* the memory useage to increase 🙈 

This PR changes the sample data to be random data generated by dask, instead of repeating existing data. Although the cell detection results won't be meaningful on this data, it provides a easy way to run memory benchmarks.

To confirm this works, here's the memory usage of just detection, which shows a clear increase when the array size is increased:

## Repeats = 1

![1-rep](https://user-images.githubusercontent.com/6197628/221828389-d1408812-090a-4ac9-b99f-40cab00a1f13.png)

## Repeats = 2
![2-rep](https://user-images.githubusercontent.com/6197628/221828402-35b8eb2d-dd37-4fd1-8c8e-b0c16d3a7c32.png)
