### PR TITLE
Remove print statment from 3D filter

### DIFF
--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -77,7 +77,6 @@ class VolumeFilter(object):
             plane, mask = result.get()
 
             logger.debug(f"Plane {self.z} received for 3D filtering")
-            print(f"Plane {self.z} received for 3D filtering")
 
             logger.debug(f"Adding plane {self.z} for 3D filtering")
             self.ball_filter.append(plane, mask)


### PR DESCRIPTION
This loop already has a `tqdm` progress bar, so the print statement is redundant and interrupts the progress bar.