### PR TITLE
avoid using deprecated pkg_resources

### DIFF
--- a/src/cellfinder_core/tools/source_files.py
+++ b/src/cellfinder_core/tools/source_files.py
@@ -1,6 +1,9 @@
 from pathlib import Path
+
+
 def source_config_cellfinder():
     return Path(__file__).parent.parent / "config" / "cellfinder.conf"
 
+
 def source_custom_config_cellfinder():
-    return  Path(__file__).parent.parent / "config" / "cellfinder.conf.custom"
+    return Path(__file__).parent.parent / "config" / "cellfinder.conf.custom"

--- a/src/cellfinder_core/tools/source_files.py
+++ b/src/cellfinder_core/tools/source_files.py
@@ -1,11 +1,6 @@
-from pkg_resources import resource_filename
-
-
+from pathlib import Path
 def source_config_cellfinder():
-    return resource_filename("cellfinder_core", "config/cellfinder.conf")
-
+    return Path(__file__).parent.parent / "config" / "cellfinder.conf"
 
 def source_custom_config_cellfinder():
-    return resource_filename(
-        "cellfinder_core", "config/cellfinder.conf.custom"
-    )
+    return  Path(__file__).parent.parent / "config" / "cellfinder.conf.custom"


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We use `pkg_resources` which is deprecated (and therefore our tests fail).

**What does this PR do?**

Uses a relative path to config files instead of `pkg_resources.filename`.

## References

- 

## How has this PR been tested?

Tests were failing before due to the deprecation warning, and now pass.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
