### PR TITLE
Fixture for programmatic creation of synthetic data

### DIFF
--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -1,4 +1,8 @@
+import numpy as np
 import pytest
+from typing import Tuple
+
+from skimage.filters import gaussian
 
 from cellfinder_core.download import models
 from cellfinder_core.tools.prep import DEFAULT_INSTALL_PATH
@@ -11,3 +15,30 @@ def download_default_model():
     at the beginning of a pytest session.
     """
     models.main("resnet50_tv", DEFAULT_INSTALL_PATH)
+
+@pytest.fixture(scope="session")
+def synthetic_bright_spots() -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Creates a synthetic signal array with grid of bright spots in a 3d numpy array to be used for cell detection testing.
+    """
+    shape = (100, 100, 100)
+
+    signal_array = np.zeros(shape)
+    signal_array[25, 25, 25] = 1
+    signal_array[75, 25, 25] = 1
+    signal_array[25, 75, 25] = 1
+    signal_array[25, 25, 75] = 1
+    signal_array[75, 75, 25] = 1
+    signal_array[75, 25, 75] = 1
+    signal_array[25, 75, 75] = 1
+    signal_array[75, 75, 75] = 1
+
+    # convert to 16-bit integer
+    signal_array = (signal_array * 65535).astype(np.uint16)
+
+    # blur a bit to roughly match the size of the cells in the sample data
+    signal_array = gaussian(signal_array, sigma=2, preserve_range=True).astype(np.uint16)
+
+    background_array = np.zeros_like(signal_array)
+
+    return signal_array, background_array

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -20,7 +20,8 @@ def download_default_model():
 @pytest.fixture(scope="session")
 def synthetic_bright_spots() -> Tuple[np.ndarray, np.ndarray]:
     """
-    Creates a synthetic signal array with grid of bright spots in a 3d numpy array to be used for cell detection testing.
+    Creates a synthetic signal array with grid of bright spots
+    in a 3d numpy array to be used for cell detection testing.
     """
     shape = (100, 100, 100)
 

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -1,7 +1,7 @@
-import numpy as np
-import pytest
 from typing import Tuple
 
+import numpy as np
+import pytest
 from skimage.filters import gaussian
 
 from cellfinder_core.download import models
@@ -15,6 +15,7 @@ def download_default_model():
     at the beginning of a pytest session.
     """
     models.main("resnet50_tv", DEFAULT_INSTALL_PATH)
+
 
 @pytest.fixture(scope="session")
 def synthetic_bright_spots() -> Tuple[np.ndarray, np.ndarray]:
@@ -37,7 +38,9 @@ def synthetic_bright_spots() -> Tuple[np.ndarray, np.ndarray]:
     signal_array = (signal_array * 65535).astype(np.uint16)
 
     # blur a bit to roughly match the size of the cells in the sample data
-    signal_array = gaussian(signal_array, sigma=2, preserve_range=True).astype(np.uint16)
+    signal_array = gaussian(signal_array, sigma=2, preserve_range=True).astype(
+        np.uint16
+    )
 
     background_array = np.zeros_like(signal_array)
 

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -99,3 +99,14 @@ def test_floating_point_error(signal_array, background_array):
     signal_array = signal_array.astype(float)
     with pytest.raises(ValueError, match="signal_array must be integer"):
         main(signal_array, background_array, voxel_sizes)
+
+
+def test_synthetic_data(synthetic_bright_spots):
+    signal_array, background_array = synthetic_bright_spots
+    detected = main(
+        signal_array,
+        background_array,
+        voxel_sizes,
+        n_free_cpus=0,
+    )
+    assert len(detected)==8

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -109,4 +109,4 @@ def test_synthetic_data(synthetic_bright_spots):
         voxel_sizes,
         n_free_cpus=0,
     )
-    assert len(detected)==8
+    assert len(detected) == 8


### PR DESCRIPTION
## Description

Adds a fixture that generates simple synthetic signal and background arrays
Background array is black, signal array has 8 slightly blurred bright spots.

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The synthetic data is useful for testing.

**What does this PR do?**
See Description.

## References
n/a

## How has this PR been tested?
Added a test that checks cell detection finds 8 cells in the programmatically generated synthetic data, as expected.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
