### PR TITLE
Allow cellfinder tests to run on branches

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -2,8 +2,7 @@ name: tests
 
 on:
   push:
-    branches:
-      - '*'
+    branches: [ main ]
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel
           # Install the version cellfinder-core used to open this PR with
-          python -m pip install git+${{ github.event.pull_request.head.repo.html_url }}@${{ github.event.pull_request.head.sha }}
+          python -m pip install git+${{ github.event.pull_request.head.repo.html_url }}@$GITHUB_SHA
           # Install checked out copy of cellfinder
           python -m pip install .[dev]
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          # Install the version cellfinder-core used to open this PR with
-          python -m pip install git+${{ github.event.pull_request.head.repo.html_url }}@$GITHUB_SHA
+          # Install latest SHA on this cellfinder-core branch
+          python -m pip install git+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY@$GITHUB_SHA
           # Install checked out copy of cellfinder
           python -m pip install .[dev]
 


### PR DESCRIPTION
Fixes https://github.com/brainglobe/cellfinder-core/issues/72. The previous code used the `pull_request` event to get the SHA. The new version is more generic, using provided environment variables to get the checkout url.