### PR TITLE
Simplify implemention of is_low_average

### DIFF
--- a/src/cellfinder_core/detect/filters/plane/base_tile_filter.py
+++ b/src/cellfinder_core/detect/filters/plane/base_tile_filter.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import numpy as np
 from numba import jit
 
 
@@ -36,16 +37,14 @@ class BaseTileFilter:
         struct_sizes = self.size_analyser.get_sizes()
         return get_biggest_structure(struct_sizes), struct_sizes.size()
 
-    @jit
-    def is_low_average(self, tile):  # TODO: move to OutOfBrainTileFilter
-        avg = 0
-        for x in range(tile.shape[0]):
-            for y in range(tile.shape[1]):
-                avg += tile[x, y]
-        avg /= tile.shape[0] * tile.shape[1]
-        is_low = avg < self.out_of_brain_intensity_threshold
-        self.keep = not is_low
-        return is_low
+
+@jit
+def is_low_average(tile: np.ndarray, threshold: float) -> bool:
+    """
+    Return `True` if the average value of *tile* is below *threshold*.
+    """
+    avg = np.mean(tile)
+    return avg < threshold
 
 
 class OutOfBrainTileFilter(BaseTileFilter):

--- a/src/cellfinder_core/detect/filters/plane/tile_walker.py
+++ b/src/cellfinder_core/detect/filters/plane/tile_walker.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from cellfinder_core.detect.filters.plane.base_tile_filter import (
     OutOfBrainTileFilter,
+    is_low_average,
 )
 
 
@@ -59,7 +60,10 @@ class TileWalker(object):
             self.y = y
             self.ftf.set_tile(tile)
             if self.ftf.out_of_brain_intensity_threshold:
-                if not self.ftf.is_low_average(tile):
+                self.ftf.keep = not is_low_average(
+                    tile, self.ftf.out_of_brain_intensity_threshold
+                )
+                if self.ftf.keep:
                     mask_x = self.x // self.tile_width
                     mask_y = self.y // self.tile_height
                     self.good_tiles_mask[mask_x, mask_y] = True


### PR DESCRIPTION
In my 3D filtering branch, `is_low_average` was causing issues with `numba` not being able to compile it using nopython mode. This PR fixes that, and greatly simplifies `is_low_average`.