### PR TITLE
Pin tensorflow to < 2.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ dependencies = [
     "numpy",
     "scikit-image",
     "scikit-learn",
-    "tensorflow-macos>=2.5.0; platform_system=='Darwin' and platform_machine=='arm64'",
-    "tensorflow>=2.5.0; platform_system!='Darwin' or platform_machine!='arm64'",
+    # See https://github.com/brainglobe/cellfinder-core/issues/103 for < 2.12.0 pin
+    "tensorflow-macos>=2.5.0,<2.12.0; platform_system=='Darwin' and platform_machine=='arm64'",
+    "tensorflow>=2.5.0,<2.12.0; platform_system!='Darwin' or platform_machine!='arm64'",
     "tifffile",
     "tqdm",
 ]


### PR DESCRIPTION
See https://github.com/brainglobe/cellfinder-core/issues/103 - tests are failing with the new version of tensorflow, so until we've sorted it probably easiest to pin the tensorflow version.