### PR TITLE
Convert CellDetector to numba

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,8 @@ filterwarnings = [
     "error",
     # Raised by tensorflow; should be removed when tensorflow 2.12.0 is released. Fix is:
     # https://github.com/tensorflow/tensorflow/commit/b23c5750c9f35a87872793eef7c56e74ec55d4a7
-    "ignore:`np.bool8` is a deprecated alias for `np.bool_`"
+    "ignore:`np.bool8` is a deprecated alias for `np.bool_`",
+    "ignore:.*:numba.core.errors.NumbaTypeSafetyWarning"
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "serial",
 ]
-log_level = "DEBUG"
+log_level = "WARNING"
 
 [tool.black]
 target-version = ['py38', 'py39', 'py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ filterwarnings = [
     # Raised by tensorflow; should be removed when tensorflow 2.12.0 is released. Fix is:
     # https://github.com/tensorflow/tensorflow/commit/b23c5750c9f35a87872793eef7c56e74ec55d4a7
     "ignore:`np.bool8` is a deprecated alias for `np.bool_`",
+    # See https://github.com/numba/numba/issues/8676
     "ignore:.*:numba.core.errors.NumbaTypeSafetyWarning"
 ]
 markers = [

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -127,9 +127,12 @@ class CellDetector:
         # in the .previous_layer class attribute
         layer = layer.astype(np.uint64)
 
+        # The 'magic numbers' below are chosen so that the maximum number
+        # representable in each data type is converted to 2**64 - 1, the
+        # maximum representable number in uint64.
         nbits = np.iinfo(source_dtype).bits
         if nbits == 8:
-            layer *= numba.uint64(72340172838076656)
+            layer *= numba.uint64(72340172838076673)
         elif nbits == 16:
             layer *= numba.uint64(281479271743489)
         elif nbits == 32:

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -61,10 +61,8 @@ class CellDetector:
         self.shape = width, height
         self.z = start_z
 
-        assert connect_type in (
-            4,
-            8,
-        ), 'Connection type must be one of 4,8 got "{}"'.format(connect_type)
+        if connect_type not in (4, 8):
+            raise ValueError("Connection type must be one of [4, 8]")
         self.connect_type = connect_type
 
         self.SOMA_CENTRE_VALUE = UINT64_MAX
@@ -82,11 +80,8 @@ class CellDetector:
     def process(
         self, layer
     ):  # WARNING: inplace  # WARNING: ull may be overkill but ulong required
-        assert [e for e in layer.shape[:2]] == [
-            e for e in self.shape
-        ], 'CellDetector layer error, expected shape "{}", got "{}"'.format(
-            self.shape, [e for e in layer.shape[:2]]
-        )
+        if [e for e in layer.shape[:2]] != [e for e in self.shape]:
+            raise ValueError("layer does not have correct shape")
 
         source_dtype = layer.dtype
         layer = layer.astype(np.uint64)
@@ -106,11 +101,7 @@ class CellDetector:
         elif source_dtype == np.uint64:
             pass
         else:
-            raise ValueError(
-                "Expected layer of any type from "
-                "np.uint8, np.uint16, np.uint32, np.uint64,"
-                "got: {}".format(source_dtype)
-            )
+            raise ValueError("Layer does not have uint data type")
 
         if self.connect_type == 4:
             self.previous_layer = self.connect_four(layer)

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import numpy as np
+from numba import jit
 from numba.core import types
 from numba.typed import Dict
 
@@ -12,18 +13,17 @@ class Point:
     z: int
 
 
-ULLONG_MAX = 18446744073709551615  # (2**64) -1
+UINT64_MAX = np.iinfo(np.uint64).max
 N_NEIGHBOURS_4_CONNECTED = 3  # top left, below
 N_NEIGHBOURS_8_CONNECTED = 13  # all the 9 below + the 4 before on same plane
 
 
+@jit
 def get_non_zero_ull_min(values):
-    min_val = ULLONG_MAX
-    for i in range(len(values)):
-        s_id = values[i]
-        if s_id != 0:
-            if s_id < min_val:
-                min_val = s_id
+    min_val = UINT64_MAX
+    for v in values:
+        if v != 0 and v < min_val:
+            min_val = v
     return min_val
 
 
@@ -67,7 +67,7 @@ class CellDetector:
         ), 'Connection type must be one of 4,8 got "{}"'.format(connect_type)
         self.connect_type = connect_type
 
-        self.SOMA_CENTRE_VALUE = ULLONG_MAX
+        self.SOMA_CENTRE_VALUE = UINT64_MAX
 
         # position to append in stack
         # FIXME: replace by keeping start_z and self.z > self.start_Z

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -18,18 +18,13 @@ N_NEIGHBOURS_4_CONNECTED = 3  # top left, below
 N_NEIGHBOURS_8_CONNECTED = 13  # all the 9 below + the 4 before on same plane
 
 
-@jit
+@jit(nopython=True)
 def get_non_zero_ull_min(values):
     min_val = UINT64_MAX
     for v in values:
         if v != 0 and v < min_val:
             min_val = v
     return min_val
-
-
-def get_non_zero_ull_min_wrapper(values):  # wrapper for testing purposes
-    assert len(values) == 10
-    return get_non_zero_ull_min(values)
 
 
 def get_structure_centre(structure):

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -32,12 +32,12 @@ def get_non_zero_ull_min(values):
 
 
 @jit(nopython=True)
-def get_from_dict_or_return(d: dict, a):
+def traverse_dict(d: dict, a):
     """
     Traverse d, until a is not present as a key.
     """
     if a in d:
-        return get_from_dict_or_return(d, d[a])
+        return traverse_dict(d, d[a])
     else:
         return a
 
@@ -303,9 +303,7 @@ class CellDetector:
         """
         for i, neighbour_id in enumerate(neighbour_ids):
             # walk up the chain of obsolescence
-            neighbour_id = int(
-                get_from_dict_or_return(self.obsolete_ids, neighbour_id)
-            )
+            neighbour_id = int(traverse_dict(self.obsolete_ids, neighbour_id))
             neighbour_ids[i] = neighbour_id
 
         # Get minimum of all non-obsolete IDs

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List
 
 import numba
@@ -9,16 +10,11 @@ from numba.typed import Dict
 from numba.types import DictType
 
 
-@jitclass
+@dataclass
 class Point:
     x: int
     y: int
     z: int
-
-    def __init__(self, x, y, z):
-        self.x = x
-        self.y = y
-        self.z = z
 
 
 UINT64_MAX = np.iinfo(np.uint64).max
@@ -258,17 +254,6 @@ class CellDetector:
     def get_cell_centres(self):
         cell_centres = self.structures_to_cells()
         return cell_centres
-
-    def get_coords_list(self):
-        # TODO: cache (attribute)
-        coords_arrays = self.get_coords_dict()
-        # Convert from arrays to dicts
-        coords = {}
-        for sid in coords_arrays:
-            coords[sid] = []
-            for row in coords_arrays[sid]:
-                coords[sid].append(Point(row[0], row[1], row[2]))
-        return coords
 
     def get_coords_dict(self):
         return self.coords_maps

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 import numpy as np
+from numba.core import types
+from numba.typed import Dict
 
 
 @dataclass
@@ -251,7 +253,9 @@ class StructureManager:
     def __init__(self):
         # Mapping from obsolete IDs to the IDs that they have been
         # made obsolete by
-        self.obsolete_ids: dict[int, int] = {}
+        self.obsolete_ids = Dict.empty(
+            key_type=types.int64, value_type=types.int64
+        )
         # Mapping from IDs to list of points in that structure
         self.coords_maps = defaultdict(list)
 
@@ -272,7 +276,11 @@ class StructureManager:
         updated_id = self.sanitise_ids(neighbour_ids)
         self.merge_structures(updated_id, neighbour_ids)
 
-        p = {"x": x, 'y': y, 'z': z}  # Necessary to split definition on some machines
+        p = {
+            "x": x,
+            "y": y,
+            "z": z,
+        }  # Necessary to split definition on some machines
         self.coords_maps[updated_id].append(p)  # Add point for that structure
 
         return updated_id

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -125,16 +125,13 @@ class CellDetector:
         :param layer:
         :return:
         """
-        # Labels of structures at left, top, below
-        neighbour_ids = [0] * N_NEIGHBOURS_4_CONNECTED
-
         for y in range(layer.shape[1]):
             for x in range(layer.shape[0]):
                 if layer[x, y] == self.SOMA_CENTRE_VALUE:
-                    for i in range(N_NEIGHBOURS_4_CONNECTED):  # reset
-                        neighbour_ids[
-                            i
-                        ] = 0  # Labels of structures at left, top, below
+                    # Labels of structures at left, top, below
+                    neighbour_ids = np.zeros(
+                        N_NEIGHBOURS_4_CONNECTED, dtype=np.uint64
+                    )
                     # If in bounds look at neighbours
                     if x > 0:
                         neighbour_ids[0] = layer[x - 1, y]
@@ -170,15 +167,11 @@ class CellDetector:
         :param layer:
         :return:
         """
-        # Labels of neighbour structures touching before
         neighbour_ids = [0] * N_NEIGHBOURS_8_CONNECTED
 
         for y in range(layer.shape[1]):
             for x in range(layer.shape[0]):
                 if layer[x, y] == self.SOMA_CENTRE_VALUE:
-                    for i in range(N_NEIGHBOURS_8_CONNECTED):  # reset
-                        neighbour_ids[i] = 0
-
                     # If in bounds look at neighbours
                     if x > 0 and y > 0:
                         neighbour_ids[0] = layer[x - 1, y - 1]

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -348,6 +348,7 @@ class StructureManager:
         return cell_centres
 
 
+@jit
 def is_new_structure(neighbour_ids):
     for i in range(len(neighbour_ids)):
         if neighbour_ids[i] != 0:

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numba
 import numpy as np
 from numba import jit
@@ -277,7 +279,7 @@ class CellDetector:
         """
         self.coords_maps[sid] = np.row_stack((self.coords_maps[sid], point))
 
-    def add(self, x: int, y: int, z: int, neighbour_ids: list[int]) -> int:
+    def add(self, x: int, y: int, z: int, neighbour_ids: List[int]) -> int:
         """
         For the current coordinates takes all the neighbours and find the
         minimum structure including obsolete structures mapping to any of
@@ -300,7 +302,7 @@ class CellDetector:
         self.add_point(updated_id, point)
         return updated_id
 
-    def sanitise_ids(self, neighbour_ids: list[int]) -> int:
+    def sanitise_ids(self, neighbour_ids: List[int]) -> int:
         """
         Get the smallest ID of all the structures that are connected to IDs
         in `neighbour_ids`.
@@ -323,7 +325,7 @@ class CellDetector:
         return int(updated_id)
 
     def merge_structures(
-        self, updated_id: int, neighbour_ids: list[int]
+        self, updated_id: int, neighbour_ids: List[int]
     ) -> None:
         """
         For all the neighbours, reassign all the points of neighbour to

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -86,25 +86,11 @@ class CellDetector:
         if [e for e in layer.shape[:2]] != [e for e in self.shape]:
             raise ValueError("layer does not have correct shape")
 
-        source_dtype = layer.dtype
+        LAYER_MAX = np.iinfo(layer.dtype).max
+        # Have to cast layer to a concrete data type in order to save it
+        # in the .previous_layer class attribute
         layer = layer.astype(np.uint64)
-
-        # The 'magic numbers' below are chosen so that the maximum number
-        # representable in each data type is converted to 2**64 - 1, the
-        # maximum representable number in uint64.
-        if source_dtype == np.uint8:
-            # 2**56 + 2**48 + 2**40 + 2**32 + 2**24 + 2**16 + 2**8 + 1
-            layer *= 72340172838076673  # TEST:
-        elif source_dtype == np.uint16:
-            # 2**48 + 2**32 + 2**16 + 1
-            layer *= 281479271743489
-        elif source_dtype == np.uint32:
-            # 2**32 + 1
-            layer *= 4294967297
-        elif source_dtype == np.uint64:
-            pass
-        else:
-            raise ValueError("Layer does not have uint data type")
+        layer = layer * (UINT64_MAX // LAYER_MAX)
 
         if self.connect_type == 4:
             self.previous_layer = self.connect_four(layer)

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -130,10 +130,7 @@ class VolumeFilter(object):
         )
 
         cells = []
-        for (
-            cell_id,
-            cell_points,
-        ) in self.cell_detector.get_coords_list().items():
+        for cell_id, cell_points in self.cell_detector.coords_maps.items():
             cell_volume = len(cell_points)
 
             if cell_volume < max_cell_volume:

--- a/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
+++ b/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
@@ -4,14 +4,14 @@ import pytest
 from cellfinder_core.detect.filters.volume.structure_detection import (
     CellDetector,
     Point,
-    get_non_zero_ull_min_wrapper,
+    get_non_zero_ull_min,
     get_structure_centre_wrapper,
 )
 
 
 def test_get_non_zero_ull_min():
-    assert get_non_zero_ull_min_wrapper(list(range(10))) == 1
-    assert get_non_zero_ull_min_wrapper([0] * 10) == (2**64) - 1
+    assert get_non_zero_ull_min(np.arange(10, dtype=np.uint64)) == 1
+    assert get_non_zero_ull_min(np.zeros(10, dtype=np.uint64)) == (2**64) - 1
 
 
 @pytest.fixture()

--- a/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
+++ b/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
@@ -9,6 +9,16 @@ from cellfinder_core.detect.filters.volume.structure_detection import (
 )
 
 
+def coords_to_points(coords_arrays):
+    # Convert from arrays to dicts
+    coords = {}
+    for sid in coords_arrays:
+        coords[sid] = []
+        for row in coords_arrays[sid]:
+            coords[sid].append(Point(row[0], row[1], row[2]))
+    return coords
+
+
 def test_get_non_zero_ull_min():
     assert get_non_zero_ull_min(np.arange(10, dtype=np.uint64)) == 1
     assert get_non_zero_ull_min(np.zeros(10, dtype=np.uint64)) == (2**64) - 1
@@ -119,5 +129,5 @@ def test_detection(dtype, pixels, expected_coords):
     for plane in data:
         detector.process(plane)
 
-    coords = detector.get_coords_list()
-    assert coords == expected_coords
+    coords = detector.get_coords_dict()
+    assert coords_to_points(coords) == expected_coords


### PR DESCRIPTION
This is the final peice in the puzzle for https://github.com/brainglobe/cellfinder-core/issues/89, converting the `CellDetector` class to numba. Some comments for context:

- Erorrs raised in numba code must have a message determined at compile time, which means I had to re-write several to avoid format strings.
- `connect_eight()` isn't touched by this PR. It isn't tested by our test suite, and I think it's not possible for a user to run that method anyway. If we want to keep `connect_eight()`, I'd advocate for doing a numba translation and adding tests at the same time in a new PR (I've opened https://github.com/brainglobe/cellfinder-core/issues/111 for this)
- I had to merge `StructureManager` into `CellDetector` (it's not possible to use one `jitclass` in another `jitclass`)


After this PR, running `benchmarks_3d.py` gives:
```
4.304 <module>  filter_3d.py:1
└─ 4.304 VolumeFilter._run_filter  cellfinder_core/detect/filters/volume/volume_filter.py:104
   ├─ 4.091 wrapper  numba/experimental/jitclass/boxing.py:59
   │     [17291 frames hidden]  numba, .., llvmlite, colorama, _colle...
   └─ 0.213 BallFilter.walk  cellfinder_core/detect/filters/volume/ball_filter.py:129
      ├─ 0.164 CPUDispatcher._compile_for_args  numba/core/dispatcher.py:388
      │     [923 frames hidden]  numba, llvmlite, colorama, _collectio...
      └─ 0.049 _walk  cellfinder_core/detect/filters/volume/ball_filter.py:197
```
Confirming that `connect_four` runs quicker than 0.049 seconds with the conversion to numba. This is similar or better than the original Cython implementation, where it also didn't show up on the pyinstrument trace: https://github.com/brainglobe/cellfinder-core/issues/89#issue-1604899152

Fixes https://github.com/brainglobe/cellfinder-core/issues/89.