### PR TITLE
Fix test coverage data collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ build = "cp38-* cp39-* cp310-*"
 archs = ["x86_64", "arm64"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=src/cellfinder_core"
+addopts = "--cov=cellfinder_core --cov-report=xml"
 filterwarnings = [
     "error",
     # Raised by tensorflow; should be removed when tensorflow 2.12.0 is released. Fix is:

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
     3.10: py310
 
 [testenv]
-commands = python -m pytest -v --color=yes --cov --cov-report=xml
+commands = python -m pytest -v --color=yes
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
Fixes https://github.com/brainglobe/cellfinder-core/issues/86. Since the coverage config was already listed in `pyproject.toml`, I migrated it to there from `tox.ini` and fixed it.