### PR TITLE
Collect coverage of numba decorated code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,12 @@
 comment: false
+
+
+# Add a numba flag to any files that contain code jit compiled
+# with numba.
+flags:
+  numba:
+    paths:
+      - src/cellfinder_core/detect/filters/plane/tile_walker.py
+      - src/cellfinder_core/detect/filters/volume/ball_filter.py
+      - src/cellfinder_core/detect/filters/volume/structure_detection.py
+    carryforward: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,10 @@ comment: false
 
 
 # Add a numba flag to any files that contain code jit compiled
-# with numba.
+# with numba. Tests are run without Numba compilation on the main
+# branch to collect code coverage, and the carryforward flags are
+# used to make sure coverage of these files does not decrease on
+# pull requests.
 flags:
   numba:
     paths:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           path: "~/.cellfinder"
           key: models-${{ hashFiles('~/.cellfinder/**') }}
-      - uses: neuroinformatics-unit/actions/test@v1.0.4
+      - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -38,23 +38,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-  test_numba_disabled:
-    name: Run tests with Numba disabled to collect code coverage
-    runs-on: ubuntu-latest
-    env:
-       NUMBA_DISABLE_JIT: "1"
-
-    steps:
-      - name: Cache tensorflow model
-        uses: actions/cache@v3
-        with:
-          path: "~/.cellfinder"
-          key: models-${{ hashFiles('~/.cellfinder/**') }}
-      - uses: neuroinformatics-unit/actions/test@v2
-        with:
-          python-version: "3.10"
-          codecov-flags: "numba"
-
 
   # Run cellfinder tests to make sure cellfinder is still compatible
   # with cellfinder-core

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -50,9 +50,10 @@ jobs:
         with:
           path: "~/.cellfinder"
           key: models-${{ hashFiles('~/.cellfinder/**') }}
-      - uses: neuroinformatics-unit/actions/test@v1.0.4
+      - uses: neuroinformatics-unit/actions/test@v2
         with:
           python-version: "3.10"
+          codecov-flags: "numba"
 
 
   # Run cellfinder tests to make sure cellfinder is still compatible

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,21 +21,15 @@ jobs:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10"]
-        disable-numba: ["0"]
         # Include one windows, one macos run, and
         # one with Numba disabled to collect code coverage
         include:
         - os: macos-latest
           python-version: "3.9"
-          disable-numba: "0"
         - os: windows-latest
           python-version: "3.9"
-          disable-numba: "0"
         - os: ubuntu-latest
           python-version: "3.10"
-          disable-numba: "1"
-    env:
-       NUMBA_DISABLE_JIT: ${{ matrix.disable-numba }}
 
     steps:
       - name: Cache tensorflow model
@@ -46,6 +40,23 @@ jobs:
       - uses: neuroinformatics-unit/actions/test@v1.0.4
         with:
           python-version: ${{ matrix.python-version }}
+
+  test_numba_disabled:
+    name: Run tests with Numba disabled to collect code coverage
+    runs-on: ubuntu-latest
+    env:
+       NUMBA_DISABLE_JIT: "1"
+
+    steps:
+      - name: Cache tensorflow model
+        uses: actions/cache@v3
+        with:
+          path: "~/.cellfinder"
+          key: models-${{ hashFiles('~/.cellfinder/**') }}
+      - uses: neuroinformatics-unit/actions/test@v1.0.4
+        with:
+          python-version: "3.10"
+
 
   # Run cellfinder tests to make sure cellfinder is still compatible
   # with cellfinder-core

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -27,13 +27,15 @@ jobs:
         include:
         - os: macos-latest
           python-version: "3.9"
+          disable-numba: "0"
         - os: windows-latest
           python-version: "3.9"
+          disable-numba: "0"
         - os: ubuntu-latest
           python-version: "3.10"
           disable-numba: "1"
     env:
-       NUMBA_DISABLE_JIT: ${{ matrix.disable_numba }}
+       NUMBA_DISABLE_JIT: ${{ matrix.disable-numba }}
 
     steps:
       - name: Cache tensorflow model

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,15 +21,12 @@ jobs:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10"]
-        # Include one windows, one macos run, and
-        # one with Numba disabled to collect code coverage
+        # Include one windows, one macos run
         include:
         - os: macos-latest
           python-version: "3.9"
         - os: windows-latest
           python-version: "3.9"
-        - os: ubuntu-latest
-          python-version: "3.10"
 
     steps:
       - name: Cache tensorflow model

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -21,6 +21,7 @@ jobs:
         # Run all supported Python versions on linux
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10"]
+        disable-numba: ["0"]
         # Include one windows, one macos run, and
         # one with Numba disabled to collect code coverage
         include:
@@ -30,7 +31,7 @@ jobs:
           python-version: "3.9"
         - os: ubuntu-latest
           python-version: "3.10"
-          disable_numba: "1"
+          disable-numba: "1"
     env:
        NUMBA_DISABLE_JIT: ${{ matrix.disable_numba }}
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,14 +19,21 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
-        # Include one windows and macos run
+        python-version: ["3.8", "3.9", "3.10"]
+        # Include one windows, one macos run, and
+        # one with Numba disabled to collect code coverage
         include:
         - os: macos-latest
           python-version: "3.9"
         - os: windows-latest
           python-version: "3.9"
+        - os: ubuntu-latest
+          python-version: "3.10"
+          disable_numba: "1"
+    env:
+       NUMBA_DISABLE_JIT: ${{ matrix.disable_numba }}
+
     steps:
       - name: Cache tensorflow model
         uses: actions/cache@v3

--- a/.github/workflows/test_numba_off.yml
+++ b/.github/workflows/test_numba_off.yml
@@ -1,0 +1,27 @@
+name: Test with numba turned off
+# These tests are relatively slow (~20 minutes), but are used
+# to collect code coverage on areas of code that are otherwise
+# optimised by numba.
+
+on:
+  push:
+    branches: [ main ]
+
+
+jobs:
+  test_numba_disabled:
+    name: Run tests
+    runs-on: ubuntu-latest
+    env:
+       NUMBA_DISABLE_JIT: "1"
+
+    steps:
+      - name: Cache tensorflow model
+        uses: actions/cache@v3
+        with:
+          path: "~/.cellfinder"
+          key: models-${{ hashFiles('~/.cellfinder/**') }}
+      - uses: neuroinformatics-unit/actions/test@v2
+        with:
+          python-version: "3.10"
+          codecov-flags: "numba"

--- a/tox.ini
+++ b/tox.ini
@@ -15,3 +15,5 @@ deps =
     pytest
     pytest-cov
     pytest-timeout
+passenv =
+    NUMBA_DISABLE_JIT


### PR DESCRIPTION
Fixes https://github.com/brainglobe/cellfinder-core/issues/110. This adds a new CI workflow that only runs on `main` that disables numba, and therefore collects code coverage for the parts of the code that would otherwise be optimised by numba. The tests are slow (~20 mins), but not unreasonably slow, so running them only on commits to `main` seems like a good compromise.

I've also enabled carryforward flags for these parts of the code in codecov. This will automatically carry forward the covered lines on main to pull requests, so coverage isn't going up and down in `main` compared to pull requests where the new workflow isn't run.