### PR TITLE
Remove manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include src/cellfinder_core/config/*
-global-include *.pxd
-global-include *.pyx


### PR DESCRIPTION
Fixes https://github.com/brainglobe/cellfinder-core/issues/96. As intended, this speeds up building the distribution. The entries are redundant now we're not using Cython, and setuptools_scm will make sure that the file in cellfinder_core/config is included in the distribution.