### PR TITLE
Test for error when data dimensionality is wrong

### DIFF
--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -94,7 +94,7 @@ def main(
     callback = callback or (lambda *args, **kwargs: None)
 
     if signal_array.ndim != 3:
-        raise IOError("Input data must be 3D")
+        raise ValueError("Input data must be 3D")
 
     setup_params = (
         signal_array[0, :, :],

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -110,3 +110,18 @@ def test_synthetic_data(synthetic_bright_spots):
         n_free_cpus=0,
     )
     assert len(detected) == 8
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 4])
+def test_data_dimension_error(ndim):
+    # Check for an error when non-3D data input
+    shape = (2, 3, 4, 5)[:ndim]
+    signal_array = np.random.randint(
+        low=0, high=2**16, size=shape, dtype=np.uint16
+    )
+    background_array = np.random.randint(
+        low=0, high=2**16, size=shape, dtype=np.uint16
+    )
+
+    with pytest.raises(ValueError, match="Input data must be 3D"):
+        main(signal_array, background_array, voxel_sizes)


### PR DESCRIPTION
Adds a bit more test coverage. Also updates the error type from `IOError` to `ValueError`, as the error is being raised because of an issue with a value passed to a function, not an issue with input/output.