### PR TITLE
Limit number of 2D filtering outputs stored in memory

### DIFF
--- a/benchmarks/filter_3d.py
+++ b/benchmarks/filter_3d.py
@@ -28,6 +28,7 @@ mp_3d_filter = VolumeFilter(
     soma_diameter=soma_diameter,
     setup_params=setup_params,
     planes_paths_range=signal_array,
+    n_locks_release=1,
 )
 
 # Use random data for mask data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pyinstrument",
     "pytest",
     "pytest-cov",
+    "pytest-mock",
     "pytest-timeout",
     "tox",
 ]

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -185,7 +185,7 @@ def _run_func_with_lock(func, arg, lock: Lock):
 
 
 def _map_with_locks(
-    func, iterable: Sequence, worker_pool
+    func, iterable: Sequence, worker_pool: multiprocessing.pool.Pool
 ) -> Tuple[Queue, List[Lock]]:
     """
     Map a function to arguments, blocking execution.

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -24,6 +24,7 @@ import numpy as np
 from imlib.cells.cells import Cell
 from imlib.general.system import get_num_processes
 
+from cellfinder_core import logger
 from cellfinder_core.detect.filters.plane import TileProcessor
 from cellfinder_core.detect.filters.setup_filters import setup_tile_filtering
 from cellfinder_core.detect.filters.volume.volume_filter import VolumeFilter
@@ -154,6 +155,7 @@ def main(
 
         # Release the first set of locks for the 2D filtering
         for i in range(ball_z_size):
+            logger.debug(f"🔓 Releasing lock for plane {i}")
             locks[i].release()
 
         # Start 3D filter

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -156,7 +156,7 @@ def main(
         )
 
         # Release the first set of locks for the 2D filtering
-        for i in range(n_ball_procs + ball_z_size):
+        for i in range(min(n_ball_procs + ball_z_size, len(locks))):
             logger.debug(f"🔓 Releasing lock for plane {i}")
             locks[i].release()
 

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -87,14 +87,12 @@ class VolumeFilter(object):
             # .get() blocks until the result is available
             plane, mask = result.get()
 
-            logger.debug(f"Plane {self.z} received for 3D filtering")
-
-            logger.debug(f"Adding plane {self.z} for 3D filtering")
             self.ball_filter.append(plane, mask)
 
             if self.ball_filter.ready:
                 # Let the next 2D filter run
                 if z + 1 < len(locks):
+                    logger.debug(f"🔓 Releasing lock for plane {z + 1}")
                     locks[z + 1].release()
                 self._run_filter()
 
@@ -107,22 +105,19 @@ class VolumeFilter(object):
         return self.get_results()
 
     def _run_filter(self):
-        logger.debug(f"Ball filtering plane {self.z}")
+        logger.debug(f"🏐 Ball filtering plane {self.z}")
         self.ball_filter.walk()
 
         middle_plane = self.ball_filter.get_middle_plane()
         if self.save_planes:
             self.save_plane(middle_plane)
 
-        logger.debug(f"Detecting structures for plane {self.z}")
+        logger.debug(f"🏫 Detecting structures for plane {self.z}")
         self.previous_plane = self.cell_detector.process(
             middle_plane, self.previous_plane
         )
 
-        logger.debug(f"Structures done for plane {self.z}")
-        logger.debug(
-            f"Skipping plane {self.z} for 3D filter" " (out of bounds)"
-        )
+        logger.debug(f"🏫 Structures done for plane {self.z}")
 
     def save_plane(self, plane):
         plane_name = f"plane_{str(self.z).zfill(4)}.tif"

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -9,6 +9,14 @@ from cellfinder_core.tools.prep import DEFAULT_INSTALL_PATH
 
 
 @pytest.fixture(scope="session")
+def n_free_cpus() -> int:
+    """
+    Set number of free CPUs while the tests are running.
+    """
+    return 0
+
+
+@pytest.fixture(scope="session")
 def download_default_model():
     """
     Check that the classification model is already downloaded

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -4,6 +4,7 @@ from math import isclose
 import imlib.IO.cells as cell_io
 import numpy as np
 import pytest
+from imlib.general.system import get_num_processes
 
 from cellfinder_core.main import main
 from cellfinder_core.tools.IO import read_with_dask
@@ -55,6 +56,25 @@ def test_detection_full(signal_array, background_array, n_free_cpus):
     )
     assert isclose(
         num_cells_validation, num_cells_test, abs_tol=DETECTION_TOLERANCE
+    )
+
+
+def test_detection_small_planes(signal_array, background_array, n_free_cpus):
+    # Check that processing works when number of planes < number of processes
+    nproc = get_num_processes(n_free_cpus)
+    n_planes = 2
+
+    pytest.mark.skipif(
+        nproc < n_planes,
+        f"Number of available processes is {nproc}. "
+        f"Test only effective if number of available processes >= {n_planes}.",
+    )
+
+    main(
+        signal_array[0:n_planes],
+        background_array[0:n_planes],
+        voxel_sizes,
+        ball_z_size=5,
     )
 
 

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -92,6 +92,7 @@ def test_detection_small_planes(
         background_array[0:n_planes],
         voxel_sizes,
         ball_z_size=5,
+        n_free_cpus=n_free_cpus,
     )
 
 

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -20,6 +20,18 @@ voxel_sizes = [5, 2, 2]
 DETECTION_TOLERANCE = 2
 
 
+class UnixFS:
+    @staticmethod
+    def rm(filename):
+        os.remove(filename)
+
+
+def test_unix_fs(mocker):
+    mocker.patch("os.remove")
+    UnixFS.rm("file")
+    os.remove.assert_called_once_with("file")
+
+
 @pytest.fixture
 def signal_array():
     return read_with_dask(signal_data_path)
@@ -59,10 +71,15 @@ def test_detection_full(signal_array, background_array, n_free_cpus):
     )
 
 
-def test_detection_small_planes(signal_array, background_array, n_free_cpus):
+def test_detection_small_planes(
+    signal_array, background_array, n_free_cpus, mocker
+):
     # Check that processing works when number of planes < number of processes
     nproc = get_num_processes(n_free_cpus)
     n_planes = 2
+
+    # Don't want to bother classifying in this test, so mock classifcation
+    mocker.patch("cellfinder_core.classify.classify.main")
 
     pytest.mark.skipif(
         nproc < n_planes,

--- a/tests/tests/test_integration/test_detection.py
+++ b/tests/tests/test_integration/test_detection.py
@@ -31,12 +31,12 @@ def background_array():
 
 # FIXME: This isn't a very good example
 @pytest.mark.slow
-def test_detection_full(signal_array, background_array):
+def test_detection_full(signal_array, background_array, n_free_cpus):
     cells_test = main(
         signal_array,
         background_array,
         voxel_sizes,
-        n_free_cpus=0,
+        n_free_cpus=n_free_cpus,
     )
     cells_validation = cell_io.get_cells(cells_validation_xml)
 
@@ -58,7 +58,7 @@ def test_detection_full(signal_array, background_array):
     )
 
 
-def test_callbacks(signal_array, background_array):
+def test_callbacks(signal_array, background_array, n_free_cpus):
     # 20 is minimum number of planes needed to find > 0 cells
     signal_array = signal_array[0:20]
     background_array = background_array[0:20]
@@ -83,7 +83,7 @@ def test_callbacks(signal_array, background_array):
         detect_callback=detect_callback,
         classify_callback=classify_callback,
         detect_finished_callback=detect_finished_callback,
-        n_free_cpus=0,
+        n_free_cpus=n_free_cpus,
     )
 
     np.testing.assert_equal(planes_done, np.arange(len(signal_array)))
@@ -101,13 +101,13 @@ def test_floating_point_error(signal_array, background_array):
         main(signal_array, background_array, voxel_sizes)
 
 
-def test_synthetic_data(synthetic_bright_spots):
+def test_synthetic_data(synthetic_bright_spots, n_free_cpus):
     signal_array, background_array = synthetic_bright_spots
     detected = main(
         signal_array,
         background_array,
         voxel_sizes,
-        n_free_cpus=0,
+        n_free_cpus=n_free_cpus,
     )
     assert len(detected) == 8
 

--- a/tests/tests/test_unit/test_detect/test_detect.py
+++ b/tests/tests/test_unit/test_detect/test_detect.py
@@ -1,0 +1,23 @@
+import multiprocessing
+
+from cellfinder_core.detect.detect import _map_with_locks
+
+
+def add_one(a: int) -> int:
+    return a + 1
+
+
+def test_map_with_locks():
+    args = [1, 2, 3, 2, 10]
+
+    with multiprocessing.Pool(2) as worker_pool:
+        result_queue, locks = _map_with_locks(add_one, args, worker_pool)
+
+        async_results = [result_queue.get() for _ in range(len(args))]
+        assert len(async_results) == len(locks) == len(args)
+
+        for lock in locks:
+            lock.release()
+
+        results = [res.get() for res in async_results]
+        assert results == [2, 3, 4, 3, 11]

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands = python -m pytest -v --color=yes
 deps =
     pytest
     pytest-cov
+    pytest-mock
     pytest-timeout
 passenv =
     NUMBA_DISABLE_JIT


### PR DESCRIPTION
After running into a bit of a dead end on `dask` (see https://github.com/brainglobe/cellfinder-core/issues/118#issuecomment-1497513776 for more info), I had a re-think and brainwave on how to solve https://github.com/brainglobe/cellfinder-core/issues/73 and might have come up with a plan...

The idea is to create a lock for each plane in the input data, and only release the lock on 2D filtering for the next `n_procs` planes when the previous plane has started being processed by the 3D filter. This replicates the behaviour before version 0.3.0, and fixes https://github.com/brainglobe/cellfinder-core/issues/73