### PR TITLE
Use bool dtype for good tiles mask

### DIFF
--- a/benchmarks/filter_3d.py
+++ b/benchmarks/filter_3d.py
@@ -31,7 +31,7 @@ mp_3d_filter = VolumeFilter(
 )
 
 # Use random data for mask data
-mask = np.random.randint(low=0, high=2, size=(42, 32), dtype=np.uint8)
+mask = np.random.randint(low=0, high=2, size=(42, 32), dtype=bool)
 
 # Fill up the 3D filter with planes
 for plane in signal_array:

--- a/src/cellfinder_core/detect/filters/plane/plane_filter.py
+++ b/src/cellfinder_core/detect/filters/plane/plane_filter.py
@@ -61,7 +61,7 @@ class TileProcessor:
         # Get tiles that are within the brain
         walker = TileWalker(plane, self.soma_diameter)
         walker.mark_bright_tiles()
-        inside_brain_tiles = walker.bright_tiles_mask.astype(np.uint8)
+        inside_brain_tiles = walker.bright_tiles_mask
 
         # Threshold the image
         thresholded_img = enhance_peaks(

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.py
@@ -116,7 +116,7 @@ class BallFilter:
                 int(np.ceil(plane_height / tile_step_height)),
                 ball_z_size,
             ),
-            dtype=np.uint8,
+            dtype=bool,
         )
         # Stores the z-index in volume at which new planes are inserted when
         # append() is called

--- a/src/cellfinder_core/detect/filters/volume/structure_splitting.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_splitting.py
@@ -50,7 +50,7 @@ def ball_filter_imgs(
 ) -> Tuple[np.ndarray, List[Point]]:
     # OPTIMISE: reuse ball filter instance
 
-    good_tiles_mask = np.ones((1, 1, volume.shape[2]), dtype=np.uint8)
+    good_tiles_mask = np.ones((1, 1, volume.shape[2]), dtype=bool)
 
     plane_width, plane_height = volume.shape[:2]
 


### PR DESCRIPTION
I see no reason why this mask can't be bool, and all tests seem to pass. This should save a little bit of memory.

This is the first of a few PRs I'm going to open to reduce memory usage. Fixes https://github.com/brainglobe/cellfinder-core/issues/128

