### PR TITLE
Don't cast planes to uint64 in structure detection

### DIFF
--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import List, Sequence, Tuple, Union
 
-import numba
 import numpy as np
 from numba import jit
 from numba.core import types
@@ -17,18 +16,15 @@ class Point:
     z: int
 
 
-UINT64_MAX = np.iinfo(np.uint64).max
-
-
 @jit(nopython=True)
 def get_non_zero_ull_min(values: np.ndarray) -> int:
     """
     Get the minimum of non-zero entries in *values*.
 
     If all entries are zero, returns maximum storeable number
-    in uint64 data type.
+    in the values array.
     """
-    min_val = UINT64_MAX
+    min_val = np.iinfo(values.dtype).max
     for v in values:
         if v != 0 and v < min_val:
             min_val = v
@@ -82,14 +78,11 @@ uint_2d_type = types.uint64[:, :]
 
 
 spec = [
-    ("SOMA_CENTRE_VALUE", types.uint64),
     ("z", types.uint64),
-    ("relative_z", types.uint64),
     ("next_structure_id", types.uint64),
     ("shape", types.UniTuple(types.int64, 2)),
     ("obsolete_ids", DictType(types.int64, types.int64)),
     ("coords_maps", DictType(types.uint64, uint_2d_type)),
-    ("previous_plane", types.uint64[:, :]),
 ]
 
 
@@ -101,13 +94,8 @@ class CellDetector:
 
     Attributes
     ----------
-    SOMA_CENTRE_VALUE :
-        The value used to (previously) mark pixels belonging to cells.
     z :
         z-index of the plane currently being processed.
-    relative_z:
-        z-index of the plane being processed, relative to the z-index of
-        the plane that was first processed.
     next_structure_id :
         The next available structure ID that has yet to be used. IDs start
         counting up from 1.
@@ -122,8 +110,6 @@ class CellDetector:
         Mapping from structure ID to the coordinates of pixels within that
         structure. Coordinates are stored in a 2D array, with the second
         axis indexing (x, y, z) coordinates.
-    previous_plane :
-        The previous plane to have been processed.
     """
 
     def __init__(self, width: int, height: int, start_z: int):
@@ -137,12 +123,6 @@ class CellDetector:
         """
         self.shape = width, height
         self.z = start_z
-
-        self.SOMA_CENTRE_VALUE = UINT64_MAX
-
-        # position to append in stack
-        # FIXME: replace by keeping start_z and self.z > self.start_Z
-        self.relative_z = 0
         self.next_structure_id = 1
 
         # Mapping from obsolete IDs to the IDs that they have been
@@ -155,39 +135,22 @@ class CellDetector:
             key_type=types.int64, value_type=uint_2d_type
         )
 
-    def process(self, plane: np.ndarray) -> None:
+    def process(
+        self, plane: np.ndarray, previous_plane: np.ndarray
+    ) -> np.ndarray:
         """
         Process a new plane.
         """
         if [e for e in plane.shape[:2]] != [e for e in self.shape]:
             raise ValueError("plane does not have correct shape")
 
-        source_dtype = plane.dtype
-        # Have to cast plane to a concrete data type in order to save it
-        # in the .previous_plane class attribute. uint64 might be overkill
-        # but needs to be at least uint32
-        plane = plane.astype(np.uint64)
-
-        # The 'magic numbers' below are chosen so that the maximum number
-        # representable in each data type is converted to 2**64 - 1, the
-        # maximum representable number in uint64.
-        nbits = np.iinfo(source_dtype).bits
-        if nbits == 8:
-            plane *= numba.uint64(72340172838076673)
-        elif nbits == 16:
-            plane *= numba.uint64(281479271743489)
-        elif nbits == 32:
-            plane *= numba.uint64(4294967297)
-
-        plane = self.connect_four(plane)
-        self.previous_plane = plane
-
-        if self.relative_z == 0:
-            self.relative_z += 1
-
+        plane = self.connect_four(plane, previous_plane)
         self.z += 1
+        return plane
 
-    def connect_four(self, plane: np.ndarray) -> np.ndarray:
+    def connect_four(
+        self, plane: np.ndarray, previous_plane: np.ndarray
+    ) -> np.ndarray:
         """
         Perform structure labelling.
 
@@ -203,9 +166,10 @@ class CellDetector:
             Plane with pixels either set to zero (no structure) or labelled
             with their structure ID.
         """
+        SOMA_CENTRE_VALUE = np.iinfo(plane.dtype).max
         for y in range(plane.shape[1]):
             for x in range(plane.shape[0]):
-                if plane[x, y] == self.SOMA_CENTRE_VALUE:
+                if plane[x, y] == SOMA_CENTRE_VALUE:
                     # Labels of structures below, left and behind
                     neighbour_ids = np.zeros(3, dtype=np.uint64)
                     # If in bounds look at neighbours
@@ -213,8 +177,8 @@ class CellDetector:
                         neighbour_ids[0] = plane[x - 1, y]
                     if y > 0:
                         neighbour_ids[1] = plane[x, y - 1]
-                    if self.relative_z > 0:
-                        neighbour_ids[2] = self.previous_plane[x, y]
+                    if previous_plane is not None:
+                        neighbour_ids[2] = previous_plane[x, y]
 
                     if is_new_structure(neighbour_ids):
                         neighbour_ids[0] = self.next_structure_id

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -17,7 +17,7 @@ class Point:
 
 
 @jit(nopython=True)
-def get_non_zero_ull_min(values: np.ndarray) -> int:
+def get_non_zero_dtype_min(values: np.ndarray) -> int:
     """
     Get the minimum of non-zero entries in *values*.
 
@@ -246,7 +246,7 @@ class CellDetector:
             neighbour_ids[i] = neighbour_id
 
         # Get minimum of all non-obsolete IDs
-        updated_id = get_non_zero_ull_min(neighbour_ids)
+        updated_id = get_non_zero_dtype_min(neighbour_ids)
         return int(updated_id)
 
     def merge_structures(

--- a/src/cellfinder_core/detect/filters/volume/structure_splitting.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_splitting.py
@@ -71,6 +71,7 @@ def ball_filter_imgs(
 
     # FIXME: hard coded type
     ball_filtered_volume = np.zeros(volume.shape, dtype=np.uint16)
+    previous_plane = None
     for z in range(volume.shape[2]):
         bf.append(volume[:, :, z].astype(np.uint16), good_tiles_mask[:, :, z])
         if bf.ready:
@@ -78,7 +79,9 @@ def ball_filter_imgs(
             middle_plane = bf.get_middle_plane()
             ball_filtered_volume[:, :, z] = middle_plane[:]
             # DEBUG: TEST: transpose
-            cell_detector.process(middle_plane.copy())
+            previous_plane = cell_detector.process(
+                middle_plane.copy(), previous_plane
+            )
     return ball_filtered_volume, cell_detector.get_cell_centres()
 
 

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -52,6 +52,8 @@ class VolumeFilter(object):
         self.threshold_value = None
         self.setup_params = setup_params
 
+        self.previous_plane = None
+
         self.ball_filter = get_ball_filter(
             plane=self.setup_params[0],
             soma_diameter=self.setup_params[1],
@@ -110,7 +112,9 @@ class VolumeFilter(object):
             self.save_plane(middle_plane)
 
         logger.debug(f"Detecting structures for plane {self.z}")
-        self.cell_detector.process(middle_plane)
+        self.previous_plane = self.cell_detector.process(
+            middle_plane, self.previous_plane
+        )
 
         logger.debug(f"Structures done for plane {self.z}")
         logger.debug(

--- a/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
+++ b/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
@@ -4,7 +4,7 @@ import pytest
 from cellfinder_core.detect.filters.volume.structure_detection import (
     CellDetector,
     Point,
-    get_non_zero_ull_min,
+    get_non_zero_dtype_min,
     get_structure_centre_wrapper,
 )
 
@@ -19,9 +19,18 @@ def coords_to_points(coords_arrays):
     return coords
 
 
-def test_get_non_zero_ull_min():
-    assert get_non_zero_ull_min(np.arange(10, dtype=np.uint64)) == 1
-    assert get_non_zero_ull_min(np.zeros(10, dtype=np.uint64)) == (2**64) - 1
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    [
+        (np.uint64, 2**64 - 1),
+        (np.uint32, 2**32 - 1),
+        (np.uint16, 2**16 - 1),
+        (np.uint8, 2**8 - 1),
+    ],
+)
+def test_get_non_zero_dtype_min(dtype, expected):
+    assert get_non_zero_dtype_min(np.arange(10, dtype=dtype)) == 1
+    assert get_non_zero_dtype_min(np.zeros(10, dtype=dtype)) == expected
 
 
 @pytest.fixture()

--- a/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
+++ b/tests/tests/test_unit/test_detect/test_filters/test_volume_filters/test_structure_detection.py
@@ -133,8 +133,9 @@ def test_detection(dtype, pixels, expected_coords):
     for pix in pixels:
         data[pix] = max_poss_value
 
+    previous_plane = None
     for plane in data:
-        detector.process(plane)
+        previous_plane = detector.process(plane, previous_plane)
 
     coords = detector.get_coords_dict()
     assert coords_to_points(coords) == expected_coords


### PR DESCRIPTION
I think this simplifies the code a bit, and also reduces the memory footprint slightly by not taking a copy of the planes and casting them to `uint64`.

Fixes https://github.com/brainglobe/cellfinder-core/issues/100.