### PR TITLE
Force typing in detect sub-module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,14 @@ fix = true
 
 [tool.ruff.isort]
 known-first-party = ["cellfinder_core"]
+
+[tool.mypy]
+python_version = "3.8"
+
+[[tool.mypy.overrides]]
+module = [
+    "cellfinder_core.detect.*",
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true

--- a/src/cellfinder_core/detect/detect.py
+++ b/src/cellfinder_core/detect/detect.py
@@ -17,7 +17,7 @@ import multiprocessing
 from datetime import datetime
 from queue import Queue
 from threading import Lock
-from typing import Callable, List, Optional, Sequence, Tuple, Union
+from typing import Callable, List, Optional, Sequence, Tuple, TypeVar, Union
 
 import dask.array as da
 import numpy as np
@@ -176,7 +176,13 @@ def main(
     return cells
 
 
-def _run_func_with_lock(func, arg, lock: Lock):
+Tin = TypeVar("Tin")
+Tout = TypeVar("Tout")
+
+
+def _run_func_with_lock(
+    func: Callable[[Tin], Tout], arg: Tin, lock: Lock
+) -> Tout:
     """
     Run a function after acquiring a lock.
     """
@@ -185,7 +191,9 @@ def _run_func_with_lock(func, arg, lock: Lock):
 
 
 def _map_with_locks(
-    func, iterable: Sequence, worker_pool: multiprocessing.pool.Pool
+    func: Callable[[Tin], Tout],
+    iterable: Sequence[Tin],
+    worker_pool: multiprocessing.pool.Pool,
 ) -> Tuple[Queue, List[Lock]]:
     """
     Map a function to arguments, blocking execution.

--- a/src/cellfinder_core/detect/filters/plane/classical_filter.py
+++ b/src/cellfinder_core/detect/filters/plane/classical_filter.py
@@ -3,7 +3,9 @@ from scipy.ndimage import gaussian_filter, laplace
 from scipy.signal import medfilt2d
 
 
-def enhance_peaks(img, clipping_value, gaussian_sigma=2.5):
+def enhance_peaks(
+    img: np.ndarray, clipping_value: float, gaussian_sigma: float = 2.5
+) -> np.ndarray:
     type_in = img.dtype
     filtered_img = medfilt2d(img.astype(np.float64))
     filtered_img = gaussian_filter(filtered_img, gaussian_sigma)

--- a/src/cellfinder_core/detect/filters/plane/plane_filter.py
+++ b/src/cellfinder_core/detect/filters/plane/plane_filter.py
@@ -23,7 +23,7 @@ class TileProcessor:
 
     clipping_value: int
     threshold_value: int
-    soma_diameter: float
+    soma_diameter: int
     log_sigma_size: float
     n_sds_above_mean_thresh: float
 

--- a/src/cellfinder_core/detect/filters/plane/tile_walker.py
+++ b/src/cellfinder_core/detect/filters/plane/tile_walker.py
@@ -1,4 +1,5 @@
 import math
+from typing import Generator, Tuple
 
 import numpy as np
 from numba import jit
@@ -22,7 +23,7 @@ class TileWalker:
         self.mark_bright_tiles().
     """
 
-    def __init__(self, img, soma_diameter):
+    def __init__(self, img: np.ndarray, soma_diameter: int) -> None:
         self.img = img
         self.img_width, self.img_height = img.shape
         self.tile_width = soma_diameter * 2
@@ -40,7 +41,7 @@ class TileWalker:
         # add 1 to ensure not 0, as disables
         self.out_of_brain_threshold = (corner_intensity + (2 * corner_sd)) + 1
 
-    def _get_tiles(self):
+    def _get_tiles(self) -> Generator[Tuple[int, int, np.ndarray], None, None]:
         """
         Generator that yields tiles of the 2D image.
 
@@ -61,7 +62,7 @@ class TileWalker:
                 ]
                 yield x, y, tile
 
-    def mark_bright_tiles(self):
+    def mark_bright_tiles(self) -> None:
         """
         Loop through tiles, and if the average value of a tile is
         greater than the intensity threshold mark the tile as bright

--- a/src/cellfinder_core/detect/filters/volume/ball_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/ball_filter.py
@@ -254,7 +254,7 @@ def _is_tile_to_check(
     tile_step_width: int,
     tile_step_height: int,
     inside_brain_tiles: np.ndarray,
-):  # Highly optimised because most time critical
+) -> bool:  # Highly optimised because most time critical
     """
     Check if the tile containing pixel (x, y) is a tile that needs checking.
     """

--- a/src/cellfinder_core/detect/filters/volume/structure_detection.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_detection.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import List, Sequence, Tuple, Union
+from typing import Dict, List, Sequence, Tuple, TypeVar, Union
 
+import numba.typed
 import numpy as np
 from numba import jit
 from numba.core import types
 from numba.experimental import jitclass
-from numba.typed import Dict
 from numba.types import DictType
 
 
@@ -31,8 +31,11 @@ def get_non_zero_dtype_min(values: np.ndarray) -> int:
     return min_val
 
 
+T = TypeVar("T")
+
+
 @jit(nopython=True)
-def traverse_dict(d: dict, a):
+def traverse_dict(d: Dict[T, T], a: T) -> T:
     """
     Traverse d, until a is not present as a key.
     """
@@ -127,11 +130,11 @@ class CellDetector:
 
         # Mapping from obsolete IDs to the IDs that they have been
         # made obsolete by
-        self.obsolete_ids = Dict.empty(
+        self.obsolete_ids = numba.typed.Dict.empty(
             key_type=types.int64, value_type=types.int64
         )
         # Mapping from IDs to list of points in that structure
-        self.coords_maps = Dict.empty(
+        self.coords_maps = numba.typed.Dict.empty(
             key_type=types.int64, value_type=uint_2d_type
         )
 
@@ -197,7 +200,7 @@ class CellDetector:
         cell_centres = self.structures_to_cells()
         return cell_centres
 
-    def get_coords_dict(self):
+    def get_coords_dict(self) -> Dict:
         return self.coords_maps
 
     def add_point(self, sid: int, point: np.ndarray) -> None:
@@ -279,7 +282,7 @@ class CellDetector:
 
 
 @jit
-def is_new_structure(neighbour_ids):
+def is_new_structure(neighbour_ids: np.ndarray) -> bool:
     for i in range(len(neighbour_ids)):
         if neighbour_ids[i] != 0:
             return False

--- a/src/cellfinder_core/detect/filters/volume/structure_splitting.py
+++ b/src/cellfinder_core/detect/filters/volume/structure_splitting.py
@@ -21,7 +21,9 @@ def get_shape(xs: np.ndarray, ys: np.ndarray, zs: np.ndarray) -> List[int]:
     return shape
 
 
-def coords_to_volume(xs, ys, zs, ball_radius=1):
+def coords_to_volume(
+    xs: np.ndarray, ys: np.ndarray, zs: np.ndarray, ball_radius: int = 1
+) -> np.ndarray:
     ball_diameter = ball_radius * 2
     # Expanded to ensure the ball fits even at the border
     expanded_shape = [
@@ -43,8 +45,8 @@ def coords_to_volume(xs, ys, zs, ball_radius=1):
 
 def ball_filter_imgs(
     volume: np.ndarray,
-    threshold_value,
-    soma_centre_value,
+    threshold_value: int,
+    soma_centre_value: int,
     ball_xy_size: int = 3,
     ball_z_size: int = 3,
 ) -> Tuple[np.ndarray, List[Point]]:

--- a/src/cellfinder_core/detect/filters/volume/volume_filter.py
+++ b/src/cellfinder_core/detect/filters/volume/volume_filter.py
@@ -77,7 +77,7 @@ class VolumeFilter(object):
         locks: List[Lock],
         *,
         callback: Callable[[int], None],
-    ):
+    ) -> List[Cell]:
         progress_bar = tqdm(total=self.n_planes, desc="Processing planes")
         for z in range(self.n_planes):
             # Get result from the queue.
@@ -110,7 +110,7 @@ class VolumeFilter(object):
         logger.debug("3D filter done")
         return self.get_results()
 
-    def _run_filter(self):
+    def _run_filter(self) -> None:
         logger.debug(f"🏐 Ball filtering plane {self.z}")
         self.ball_filter.walk()
 
@@ -125,7 +125,11 @@ class VolumeFilter(object):
 
         logger.debug(f"🏫 Structures done for plane {self.z}")
 
-    def save_plane(self, plane):
+    def save_plane(self, plane: np.ndarray) -> None:
+        if self.plane_directory is None:
+            raise ValueError(
+                "plane_directory must be set to save planes to file"
+            )
         plane_name = f"plane_{str(self.z).zfill(4)}.tif"
         f_path = os.path.join(self.plane_directory, plane_name)
         tifffile.imsave(f_path, plane.T)
@@ -186,5 +190,5 @@ class VolumeFilter(object):
         return cells
 
 
-def sphere_volume(radius):
+def sphere_volume(radius: float) -> float:
     return (4 / 3) * math.pi * radius**3


### PR DESCRIPTION
I thought this might be a good first step in tackling https://github.com/brainglobe/cellfinder-core/issues/158. It doesn't look like it helped or revealed any errors in the code itself, but seems like a good idea to finish typing the whole of the `cellfinder_core.detect`, and enforce it going forward.