### PR TITLE
Fix dynamic versioning

### DIFF
--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -3,9 +3,7 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("cellfinder-core")
 except PackageNotFoundError as e:
-    raise PackageNotFoundError(
-        "cellfinder-core package not installed"
-    ) from e
+    raise PackageNotFoundError("cellfinder-core package not installed") from e
 
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -2,12 +2,10 @@ from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("cellfinder-core")
-except PackageNotFoundError:
-    # Implying that the package we've just imported doesn't exist.
-    # Worrying, but throw an error here in this case
+except PackageNotFoundError as e:
     raise PackageNotFoundError(
-        "cellfinder-core name package is not present, but you appear to be importing it?"
-    )
+        "cellfinder-core package not installed"
+    ) from e
 
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -1,4 +1,12 @@
-__version__ = "0.3.1"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("cellfinder-core")
+except PackageNotFoundError:
+    # Implying that the package we've just imported doesn't exist.
+    # Worrying, but throw an error here in this case
+    raise PackageNotFoundError("cellfinder-core name package is not present, but you appear to be importing it?")
+
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"
 

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -5,7 +5,9 @@ try:
 except PackageNotFoundError:
     # Implying that the package we've just imported doesn't exist.
     # Worrying, but throw an error here in this case
-    raise PackageNotFoundError("cellfinder-core name package is not present, but you appear to be importing it?")
+    raise PackageNotFoundError(
+        "cellfinder-core name package is not present, but you appear to be importing it?"
+    )
 
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`cellfinder_core.__version__` is statically set at `0.3.1` but we're now at (at least) `0.4.0`.

There are also some underlying problems with building on conda because of this; for example needing to fix the cellfinder-core to version `0.3.1` in the conda-forge recipe for the brainglobe meta-package. (https://github.com/conda-forge/staged-recipes/pull/23136)

**What does this PR do?**
`cellfinder_core.__version__` will now read from the metadata in pyproject.toml. There shouldn't be a need to manually update the version number in future releases.

## References

## How has this PR been tested?
Local pip install of the package now returns the dynamic version when requested.

## Is this a breaking change?
Not a breaking change, but we need a new version uploaded because `v0.4.0` still reports that it's version `0.3.1` when requested via `cellfinder_core.__version__`.

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
