### PR TITLE
Fix mypy type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,10 @@ repos:
       rev: v1.3.0
       hooks:
           - id: mypy
+            args: [--config-file, pyproject.toml]
             additional_dependencies:
                 - types-setuptools
                 - types-requests
+                - types-tqdm
                 - dask
                 - numpy
-                - numba

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,8 +107,6 @@ fix = true
 known-first-party = ["cellfinder_core"]
 
 [tool.mypy]
-python_version = "3.8"
-ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,23 @@ known-first-party = ["cellfinder_core"]
 
 [tool.mypy]
 python_version = "3.8"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+    "fancylog.*",
+    "imlib.*",
+    "natsort.*",
+    "numba.*",
+    "tensorflow.*",
+    "tifffile.*",
+    "pyinstrument.*",
+    "pytest.*",
+    "scipy.*",
+    "skimage.*",
+    "sklearn.*",
+]
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
- Configuration file needs to be specified to get mypy to correctly run checks
- Don't bother installing numba in pre-commit environment, as it doesn't provide any types yet
- Ignore missing imports for modules without typing