### PR TITLE
Tensorflow as optional dependency?

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ dependencies = [
     "numpy",
     "scikit-image",
     "scikit-learn",
-    # See https://github.com/brainglobe/cellfinder-core/issues/103 for < 2.12.0 pin
-    "tensorflow-macos>=2.5.0,<2.12.0; platform_system=='Darwin' and platform_machine=='arm64'",
-    "tensorflow>=2.5.0,<2.12.0; platform_system!='Darwin' or platform_machine!='arm64'",
     "tifffile",
     "tqdm",
 ]
@@ -51,6 +48,12 @@ dev = [
     "pytest-mock",
     "pytest-timeout",
     "tox",
+]
+tensorflow = [
+    # See https://github.com/brainglobe/cellfinder-core/issues/103 for < 2.12.0 pin
+    # See https://github.com/brainglobe/BrainGlobe/issues/27 for optional dependency reasoning
+    "tensorflow-macos>=2.5.0,<2.12.0; platform_system=='Darwin' and platform_machine=='arm64'",
+    "tensorflow>=2.5.0,<2.12.0; platform_system!='Darwin' or platform_machine!='arm64'",
 ]
 
 [project.scripts]

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -1,17 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
-from warnings import warn
 
-# Handle tensorflow optional dependency
-_TENSORFLOW_INSTALLED = True
-_TF_VERSION = "0.0.0"
-try:
-    _TF_VERSION = version("tensorflow")
-except PackageNotFoundError as e:
-    # Optional tensorflow dependency not installed
-    warn(
-        "cellfinder-core has been installed without tensorflow. Certain functions will be unavailable. See [FIXME] for full details"
-    )
-    _TENSORFLOW_INSTALLED = False
+# Expose the tensorflow_installed flag to the rest of the package
+from .tensorflow_handle import _TENSORFLOW_INSTALLED
 
 # Handle versioning
 try:

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -1,5 +1,19 @@
 from importlib.metadata import PackageNotFoundError, version
+from warnings import warn
 
+# Handle tensorflow optional dependency
+_TENSORFLOW_INSTALLED = True
+_TF_VERSION = "0.0.0"
+try:
+    _TF_VERSION = version("tensorflow")
+except PackageNotFoundError as e:
+    # Optional tensorflow dependency not installed
+    warn(
+        "cellfinder-core has been installed without tensorflow. Certain functions will be unavailable. See [FIXME] for full details"
+    )
+    _TENSORFLOW_INSTALLED = False
+
+# Handle versioning
 try:
     __version__ = version("cellfinder-core")
 except PackageNotFoundError as e:

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import PackageNotFoundError, version
 
-# Expose the tensorflow_installed flag to the rest of the package
+# Expose the _installed flag to the rest of the package
 from .tensorflow_handle import _TENSORFLOW_INSTALLED
 
 # Handle versioning

--- a/src/cellfinder_core/classify/cube_generator.py
+++ b/src/cellfinder_core/classify/cube_generator.py
@@ -3,15 +3,20 @@ from random import shuffle
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import tensorflow as tf
 from imlib.cells.cells import Cell, group_cells_by_z
 from imlib.general.numerical import is_even
 from scipy.ndimage import zoom
 from skimage.io import imread
-from tensorflow.keras.utils import Sequence
 
 from cellfinder_core import types
 from cellfinder_core.classify.augment import AugmentationParameters, augment
+from cellfinder_core.tensorflow_handle import (
+    _TENSORFLOW_INSTALLED,
+)
+
+if _TENSORFLOW_INSTALLED:
+    import tensorflow as tf
+    from tensorflow.keras.utils import Sequence
 
 # TODO: rename, as now using dask arrays -
 #  actually should combine to one generator
@@ -21,450 +26,469 @@ class StackSizeError(Exception):
     pass
 
 
-class CubeGeneratorFromFile(Sequence):
-    """
-    Reads cubes (defined as e.g. xml, csv) from raw data to pass to
-    keras.Model.fit_generator() or keras.Model.predict_generator()
+if _TENSORFLOW_INSTALLED:
 
-    If augment=True, each augmentation selected has an "augment_likelihood"
-    chance of being applied to each cube
-    """
-
-    # TODO: shuffle within (and maybe between) batches
-    # TODO: limit workers based on RAM
-
-    def __init__(
-        self,
-        points: List[Cell],
-        signal_array: types.array,
-        background_array: types.array,
-        voxel_sizes: Tuple[int, int, int],
-        network_voxel_sizes: Tuple[int, int, int],
-        batch_size: int = 16,
-        cube_width: int = 50,
-        cube_height: int = 50,
-        cube_depth: int = 20,
-        channels: int = 2,  # No other option currently
-        classes: int = 2,
-        extract: bool = False,
-        train: bool = False,
-        augment: bool = False,
-        augment_likelihood: float = 0.1,
-        flip_axis: Tuple[int, int, int] = (0, 1, 2),
-        rotate_max_axes: Tuple[float, float, float] = (1, 1, 1),  # degrees
-        # scale=[0.5, 2],  # min, max
-        translate: Tuple[float, float, float] = (0.05, 0.05, 0.05),
-        shuffle: bool = False,
-        interpolation_order: int = 2,
-    ):
-        self.points = points
-        self.signal_array = signal_array
-        self.background_array = background_array
-        self.batch_size = batch_size
-        self.axis_2_pixel_um = float(voxel_sizes[2])
-        self.axis_1_pixel_um = float(voxel_sizes[1])
-        self.axis_0_pixel_um = float(voxel_sizes[0])
-        self.network_axis_2_pixel_um = float(network_voxel_sizes[2])
-        self.network_axis_1_pixel_um = float(network_voxel_sizes[1])
-        self.network_axis_0_pixel_um = float(network_voxel_sizes[0])
-        self.cube_width = cube_width
-        self.cube_height = cube_height
-        self.cube_depth = cube_depth
-        self.channels = channels
-        self.classes = classes
-
-        # saving training data to file
-        self.extract = extract
-
-        self.train = train
-        self.augment = augment
-        self.augment_likelihood = augment_likelihood
-        self.flip_axis = flip_axis
-        self.rotate_max_axes = rotate_max_axes
-        # self.scale = scale
-        self.translate = translate
-        self.shuffle = shuffle
-        self.interpolation_order = interpolation_order
-
-        self.scale_cubes = False
-
-        self.rescaling_factor_axis_2: float = 1
-        self.rescaling_factor_axis_1: float = 1
-        self.rescaled_cube_width: float = self.cube_width
-        self.rescaled_cube_height: float = self.cube_height
-
-        self.__check_image_sizes()
-        self.__get_image_size()
-        self.__check_z_scaling()
-        self.__check_in_plane_scaling()
-        self.__remove_outlier_points()
-        self.__get_batches()
-        if shuffle:
-            self.on_epoch_end()
-
-    def __check_image_sizes(self) -> None:
-        if len(self.signal_array) != len(self.background_array):
-            raise ValueError(
-                f"Number of signal images ({len(self.signal_array)}) does not "
-                f"match the number of background images "
-                f"({len(self.background_array)}"
-            )
-
-    def __get_image_size(self) -> None:
-        self.image_z_size = len(self.signal_array)
-        self.image_height, self.image_width = self.signal_array[0].shape
-
-    def __check_in_plane_scaling(self) -> None:
-        if self.axis_2_pixel_um != self.network_axis_2_pixel_um:
-            self.rescaling_factor_axis_2 = (
-                self.network_axis_2_pixel_um / self.axis_2_pixel_um
-            )
-            self.rescaled_cube_width = (
-                self.cube_width * self.rescaling_factor_axis_2
-            )
-            self.scale_cubes = True
-        if self.axis_1_pixel_um != self.network_axis_1_pixel_um:
-            self.rescaling_factor_axis_1 = (
-                self.network_axis_1_pixel_um / self.axis_1_pixel_um
-            )
-            self.rescaled_cube_height = (
-                self.cube_height * self.rescaling_factor_axis_1
-            )
-            self.scale_cubes = True
-
-    def __check_z_scaling(self) -> None:
-        if self.axis_0_pixel_um != self.network_axis_0_pixel_um:
-            plane_scaling_factor = (
-                self.network_axis_0_pixel_um / self.axis_0_pixel_um
-            )
-            self.num_planes_needed_for_cube = round(
-                self.cube_depth * plane_scaling_factor
-            )
-        else:
-            self.num_planes_needed_for_cube = self.cube_depth
-
-        if self.num_planes_needed_for_cube > self.image_z_size:
-            raise StackSizeError(
-                f"The number of planes provided ({self.image_z_size}) "
-                "is not sufficient for any cubes to be extracted "
-                f"(need at least {self.num_planes_needed_for_cube}). "
-                "Please check the input data"
-            )
-
-    def __remove_outlier_points(self) -> None:
+    class CubeGeneratorFromFile(Sequence):
         """
-        Remove points that won't get extracted (i.e too close to the edge)
+        Reads cubes (defined as e.g. xml, csv) from raw data to pass to
+        keras.Model.fit_generator() or keras.Model.predict_generator()
+
+        If augment=True, each augmentation selected has an "augment_likelihood"
+        chance of being applied to each cube
         """
-        self.points = [
-            point for point in self.points if self.extractable(point)
-        ]
 
-    def extractable(self, point: Cell) -> bool:
-        x0, x1, y0, y1, z0, z1 = self.__get_boundaries()
-        return (
-            x0 <= point.x <= x1 and y0 <= point.y <= y1 and z0 <= point.z <= z1
-        )
+        # TODO: shuffle within (and maybe between) batches
+        # TODO: limit workers based on RAM
 
-    def __get_boundaries(self) -> Tuple[int, int, int, int, int, int]:
-        x0 = int(round((self.cube_width / 2) * self.rescaling_factor_axis_2))
-        x1 = int(round(self.image_width - x0))
+        def __init__(
+            self,
+            points: List[Cell],
+            signal_array: types.array,
+            background_array: types.array,
+            voxel_sizes: Tuple[int, int, int],
+            network_voxel_sizes: Tuple[int, int, int],
+            batch_size: int = 16,
+            cube_width: int = 50,
+            cube_height: int = 50,
+            cube_depth: int = 20,
+            channels: int = 2,  # No other option currently
+            classes: int = 2,
+            extract: bool = False,
+            train: bool = False,
+            augment: bool = False,
+            augment_likelihood: float = 0.1,
+            flip_axis: Tuple[int, int, int] = (0, 1, 2),
+            rotate_max_axes: Tuple[float, float, float] = (1, 1, 1),  # degrees
+            # scale=[0.5, 2],  # min, max
+            translate: Tuple[float, float, float] = (0.05, 0.05, 0.05),
+            shuffle: bool = False,
+            interpolation_order: int = 2,
+        ):
+            self.points = points
+            self.signal_array = signal_array
+            self.background_array = background_array
+            self.batch_size = batch_size
+            self.axis_2_pixel_um = float(voxel_sizes[2])
+            self.axis_1_pixel_um = float(voxel_sizes[1])
+            self.axis_0_pixel_um = float(voxel_sizes[0])
+            self.network_axis_2_pixel_um = float(network_voxel_sizes[2])
+            self.network_axis_1_pixel_um = float(network_voxel_sizes[1])
+            self.network_axis_0_pixel_um = float(network_voxel_sizes[0])
+            self.cube_width = cube_width
+            self.cube_height = cube_height
+            self.cube_depth = cube_depth
+            self.channels = channels
+            self.classes = classes
 
-        y0 = int(round((self.cube_height / 2) * self.rescaling_factor_axis_1))
-        y1 = int(round(self.image_height - y0))
+            # saving training data to file
+            self.extract = extract
 
-        z0 = int(round(self.num_planes_needed_for_cube / 2))
-        z1 = self.image_z_size - z0
-        return x0, x1, y0, y1, z0, z1
+            self.train = train
+            self.augment = augment
+            self.augment_likelihood = augment_likelihood
+            self.flip_axis = flip_axis
+            self.rotate_max_axes = rotate_max_axes
+            # self.scale = scale
+            self.translate = translate
+            self.shuffle = shuffle
+            self.interpolation_order = interpolation_order
 
-    def __get_batches(self) -> None:
-        self.points_groups = group_cells_by_z(self.points)
-        # TODO: add optional shuffling of each group here
-        self.batches = []
-        for centre_plane in self.points_groups.keys():
-            points_per_plane = self.points_groups[centre_plane]
-            for i in range(0, len(points_per_plane), self.batch_size):
-                self.batches.append(points_per_plane[i : i + self.batch_size])
+            self.scale_cubes = False
 
-        self.ordered_points = []
-        for batch in self.batches:
-            for cell in batch:
-                self.ordered_points.append(cell)
+            self.rescaling_factor_axis_2: float = 1
+            self.rescaling_factor_axis_1: float = 1
+            self.rescaled_cube_width: float = self.cube_width
+            self.rescaled_cube_height: float = self.cube_height
 
-    def __len__(self) -> int:
-        """
-        Number of batches
-        :return: Number of batches per epoch
-        """
-        return len(self.batches)
+            self.__check_image_sizes()
+            self.__get_image_size()
+            self.__check_z_scaling()
+            self.__check_in_plane_scaling()
+            self.__remove_outlier_points()
+            self.__get_batches()
+            if shuffle:
+                self.on_epoch_end()
 
-    def __getitem__(
-        self, index: int
-    ) -> Union[
-        np.ndarray,
-        Tuple[np.ndarray, List[Dict[str, float]]],
-        Tuple[np.ndarray, Dict],
-    ]:
-        """
-        Generates a single batch of cubes
-        :param index:
-        :return:
-        """
-        if not self.batches:
-            raise IndexError("Empty batch. Were any cells detected?")
+        def __check_image_sizes(self) -> None:
+            if len(self.signal_array) != len(self.background_array):
+                raise ValueError(
+                    f"Number of signal images ({len(self.signal_array)})"
+                    f" does not match the number of background images "
+                    f"({len(self.background_array)}"
+                )
 
-        cell_batch = self.batches[index]
-        signal_stack, background_stack = self.__get_stacks(index)
-        images = self.__generate_cubes(
-            cell_batch, signal_stack, background_stack
-        )
+        def __get_image_size(self) -> None:
+            self.image_z_size = len(self.signal_array)
+            self.image_height, self.image_width = self.signal_array[0].shape
 
-        if self.train:
-            batch_labels = [cell.type - 1 for cell in cell_batch]
-            batch_labels = tf.keras.utils.to_categorical(
-                batch_labels, num_classes=self.classes
+        def __check_in_plane_scaling(self) -> None:
+            if self.axis_2_pixel_um != self.network_axis_2_pixel_um:
+                self.rescaling_factor_axis_2 = (
+                    self.network_axis_2_pixel_um / self.axis_2_pixel_um
+                )
+                self.rescaled_cube_width = (
+                    self.cube_width * self.rescaling_factor_axis_2
+                )
+                self.scale_cubes = True
+            if self.axis_1_pixel_um != self.network_axis_1_pixel_um:
+                self.rescaling_factor_axis_1 = (
+                    self.network_axis_1_pixel_um / self.axis_1_pixel_um
+                )
+                self.rescaled_cube_height = (
+                    self.cube_height * self.rescaling_factor_axis_1
+                )
+                self.scale_cubes = True
+
+        def __check_z_scaling(self) -> None:
+            if self.axis_0_pixel_um != self.network_axis_0_pixel_um:
+                plane_scaling_factor = (
+                    self.network_axis_0_pixel_um / self.axis_0_pixel_um
+                )
+                self.num_planes_needed_for_cube = round(
+                    self.cube_depth * plane_scaling_factor
+                )
+            else:
+                self.num_planes_needed_for_cube = self.cube_depth
+
+            if self.num_planes_needed_for_cube > self.image_z_size:
+                raise StackSizeError(
+                    f"The number of planes provided ({self.image_z_size}) "
+                    "is not sufficient for any cubes to be extracted "
+                    f"(need at least {self.num_planes_needed_for_cube}). "
+                    "Please check the input data"
+                )
+
+        def __remove_outlier_points(self) -> None:
+            """
+            Remove points that won't get extracted (i.e too close to the edge)
+            """
+            self.points = [
+                point for point in self.points if self.extractable(point)
+            ]
+
+        def extractable(self, point: Cell) -> bool:
+            x0, x1, y0, y1, z0, z1 = self.__get_boundaries()
+            return (
+                x0 <= point.x <= x1
+                and y0 <= point.y <= y1
+                and z0 <= point.z <= z1
             )
-            return images, batch_labels
-        elif self.extract:
-            batch_info = self.__get_batch_dict(cell_batch)
-            return images, batch_info
-        else:
+
+        def __get_boundaries(self) -> Tuple[int, int, int, int, int, int]:
+            x0 = int(
+                round((self.cube_width / 2) * self.rescaling_factor_axis_2)
+            )
+            x1 = int(round(self.image_width - x0))
+
+            y0 = int(
+                round((self.cube_height / 2) * self.rescaling_factor_axis_1)
+            )
+            y1 = int(round(self.image_height - y0))
+
+            z0 = int(round(self.num_planes_needed_for_cube / 2))
+            z1 = self.image_z_size - z0
+            return x0, x1, y0, y1, z0, z1
+
+        def __get_batches(self) -> None:
+            self.points_groups = group_cells_by_z(self.points)
+            # TODO: add optional shuffling of each group here
+            self.batches = []
+            for centre_plane in self.points_groups.keys():
+                points_per_plane = self.points_groups[centre_plane]
+                for i in range(0, len(points_per_plane), self.batch_size):
+                    self.batches.append(
+                        points_per_plane[i : i + self.batch_size]
+                    )
+
+            self.ordered_points = []
+            for batch in self.batches:
+                for cell in batch:
+                    self.ordered_points.append(cell)
+
+        def __len__(self) -> int:
+            """
+            Number of batches
+            :return: Number of batches per epoch
+            """
+            return len(self.batches)
+
+        def __getitem__(
+            self, index: int
+        ) -> Union[
+            np.ndarray,
+            Tuple[np.ndarray, List[Dict[str, float]]],
+            Tuple[np.ndarray, Dict],
+        ]:
+            """
+            Generates a single batch of cubes
+            :param index:
+            :return:
+            """
+            if not self.batches:
+                raise IndexError("Empty batch. Were any cells detected?")
+
+            cell_batch = self.batches[index]
+            signal_stack, background_stack = self.__get_stacks(index)
+            images = self.__generate_cubes(
+                cell_batch, signal_stack, background_stack
+            )
+
+            if self.train:
+                batch_labels = [cell.type - 1 for cell in cell_batch]
+                batch_labels = tf.keras.utils.to_categorical(
+                    batch_labels, num_classes=self.classes
+                )
+                return images, batch_labels
+            elif self.extract:
+                batch_info = self.__get_batch_dict(cell_batch)
+                return images, batch_info
+            else:
+                return images
+
+        def __get_stacks(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
+            centre_plane = self.batches[index][0].z
+
+            min_plane, max_plane = get_cube_depth_min_max(
+                centre_plane, self.num_planes_needed_for_cube
+            )
+
+            signal_stack = np.array(self.signal_array[min_plane:max_plane])
+            background_stack = np.array(
+                self.background_array[min_plane:max_plane]
+            )
+
+            return signal_stack, background_stack
+
+        def __generate_cubes(
+            self,
+            cell_batch: List[Cell],
+            signal_stack: np.ndarray,
+            background_stack: np.ndarray,
+        ) -> np.ndarray:
+            number_images = len(cell_batch)
+            images = np.empty(
+                (
+                    (number_images,)
+                    + (self.cube_height, self.cube_width, self.cube_depth)
+                    + (self.channels,)
+                )
+            )
+
+            for idx, cell in enumerate(cell_batch):
+                images = self.__populate_array_with_cubes(
+                    images, idx, cell, signal_stack, background_stack
+                )
+
             return images
 
-    def __get_stacks(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
-        centre_plane = self.batches[index][0].z
-
-        min_plane, max_plane = get_cube_depth_min_max(
-            centre_plane, self.num_planes_needed_for_cube
-        )
-
-        signal_stack = np.array(self.signal_array[min_plane:max_plane])
-        background_stack = np.array(self.background_array[min_plane:max_plane])
-
-        return signal_stack, background_stack
-
-    def __generate_cubes(
-        self,
-        cell_batch: List[Cell],
-        signal_stack: np.ndarray,
-        background_stack: np.ndarray,
-    ) -> np.ndarray:
-        number_images = len(cell_batch)
-        images = np.empty(
-            (
-                (number_images,)
-                + (self.cube_height, self.cube_width, self.cube_depth)
-                + (self.channels,)
+        def __populate_array_with_cubes(
+            self,
+            images: np.ndarray,
+            idx: int,
+            cell: Cell,
+            signal_stack: np.ndarray,
+            background_stack: np.ndarray,
+        ) -> np.ndarray:
+            if self.augment:
+                self.augmentation_parameters = AugmentationParameters(
+                    self.flip_axis,
+                    self.translate,
+                    self.rotate_max_axes,
+                    self.interpolation_order,
+                    self.augment_likelihood,
+                )
+            images[idx, :, :, :, 0] = self.__get_oriented_image(
+                cell, signal_stack
             )
-        )
-
-        for idx, cell in enumerate(cell_batch):
-            images = self.__populate_array_with_cubes(
-                images, idx, cell, signal_stack, background_stack
+            images[idx, :, :, :, 1] = self.__get_oriented_image(
+                cell, background_stack
             )
-
-        return images
-
-    def __populate_array_with_cubes(
-        self,
-        images: np.ndarray,
-        idx: int,
-        cell: Cell,
-        signal_stack: np.ndarray,
-        background_stack: np.ndarray,
-    ) -> np.ndarray:
-        if self.augment:
-            self.augmentation_parameters = AugmentationParameters(
-                self.flip_axis,
-                self.translate,
-                self.rotate_max_axes,
-                self.interpolation_order,
-                self.augment_likelihood,
-            )
-        images[idx, :, :, :, 0] = self.__get_oriented_image(cell, signal_stack)
-        images[idx, :, :, :, 1] = self.__get_oriented_image(
-            cell, background_stack
-        )
-        return images
-
-    def __get_oriented_image(
-        self, cell: Cell, image_stack: np.ndarray
-    ) -> np.ndarray:
-        x0 = int(round(cell.x - (self.rescaled_cube_width / 2)))
-        x1 = int(x0 + self.rescaled_cube_width)
-        y0 = int(round(cell.y - (self.rescaled_cube_height / 2)))
-        y1 = int(y0 + self.rescaled_cube_height)
-        image = image_stack[:, y0:y1, x0:x1]
-        image = np.moveaxis(image, 0, 2)
-
-        if self.augment:
-            # scale to isotropic, but don't scale back
-            image = augment(
-                self.augmentation_parameters, image, scale_back=False
-            )
-
-        pixel_scalings = [
-            self.cube_height / image.shape[0],
-            self.cube_width / image.shape[1],
-            self.cube_depth / image.shape[2],  # type: ignore[misc]
-            # Not sure why mypy thinks .shape[2] is out of bounds above?
-        ]
-
-        # TODO: ensure this is always the correct size
-        image = zoom(image, pixel_scalings, order=self.interpolation_order)
-        return image
-
-    @staticmethod
-    def __get_batch_dict(cell_batch: List[Cell]) -> List[Dict[str, float]]:
-        return [cell.to_dict() for cell in cell_batch]
-
-    def on_epoch_end(self) -> None:
-        """
-        Shuffle data for each epoch
-        :return: Shuffled indexes
-        """
-        shuffle(self.batches)
-
-
-class CubeGeneratorFromDisk(Sequence):
-    """
-    Reads in cubes from a list of paths for keras.Model.fit_generator() or
-    keras.Model.predict_generator()
-
-    If augment=True, each augmentation selected has a 50/50 chance of being
-    applied to each cube
-    """
-
-    def __init__(
-        self,
-        signal_list: List[Union[str, Path]],
-        background_list: List[Union[str, Path]],
-        labels: Optional[List[int]] = None,  # only if training or validating
-        batch_size: int = 16,
-        shape: Tuple[int, int, int] = (50, 50, 20),
-        channels: int = 2,
-        classes: int = 2,
-        shuffle: bool = False,
-        augment: bool = False,
-        augment_likelihood: float = 0.1,
-        flip_axis: Tuple[int, int, int] = (0, 1, 2),
-        rotate_max_axes: Tuple[int, int, int] = (45, 45, 45),  # degrees
-        # scale=[0.5, 2],  # min, max
-        translate: Tuple[float, float, float] = (0.2, 0.2, 0.2),
-        train: bool = False,  # also return labels
-        interpolation_order: int = 2,
-    ):
-        self.im_shape = shape
-        self.batch_size = batch_size
-        self.labels = labels
-        self.signal_list = signal_list
-        self.background_list = background_list
-        self.channels = channels
-        self.classes = classes
-        self.augment = augment
-        self.augment_likelihood = augment_likelihood
-        self.flip_axis = flip_axis
-        self.rotate_max_axes = rotate_max_axes
-        # self.scale = scale
-        self.translate = translate
-        self.train = train
-        self.interpolation_order = interpolation_order
-        self.indexes = np.arange(len(self.signal_list))
-        if shuffle:
-            self.on_epoch_end()
-
-    # TODO: implement scale and shear
-
-    def on_epoch_end(self) -> None:
-        """
-        Shuffle data for each epoch
-        :return: Shuffled indexes
-        """
-        self.indexes = np.arange(len(self.signal_list))
-        np.random.shuffle(self.indexes)
-
-    def __len__(self) -> int:
-        """
-        Number of batches
-        :return: Number of batches per epoch
-        """
-        return int(np.ceil(len(self.signal_list) / self.batch_size))
-
-    def __getitem__(
-        self, index: int
-    ) -> Union[
-        np.ndarray,
-        Tuple[np.ndarray, List[Dict[str, float]]],
-        Tuple[np.ndarray, Dict],
-    ]:
-        """
-        Generates a single batch of cubes
-        :param index:
-        :return:
-        """
-        # Generate indexes of the batch
-        start_index = index * self.batch_size
-        end_index = start_index + self.batch_size
-        indexes = self.indexes[start_index:end_index]
-
-        # Get data corresponding to batch
-        list_signal_tmp = [self.signal_list[k] for k in indexes]
-        list_background_tmp = [self.background_list[k] for k in indexes]
-
-        images = self.__generate_cubes(list_signal_tmp, list_background_tmp)
-
-        if self.train and self.labels is not None:
-            batch_labels = [self.labels[k] for k in indexes]
-            batch_labels = tf.keras.utils.to_categorical(
-                batch_labels, num_classes=self.classes
-            )
-            return images, batch_labels
-        else:
             return images
 
-    def __generate_cubes(
-        self,
-        list_signal_tmp: List[Union[str, Path]],
-        list_background_tmp: List[Union[str, Path]],
-    ) -> np.ndarray:
-        number_images = len(list_signal_tmp)
-        images = np.empty(
-            ((number_images,) + self.im_shape + (self.channels,))
-        )
+        def __get_oriented_image(
+            self, cell: Cell, image_stack: np.ndarray
+        ) -> np.ndarray:
+            x0 = int(round(cell.x - (self.rescaled_cube_width / 2)))
+            x1 = int(x0 + self.rescaled_cube_width)
+            y0 = int(round(cell.y - (self.rescaled_cube_height / 2)))
+            y1 = int(y0 + self.rescaled_cube_height)
+            image = image_stack[:, y0:y1, x0:x1]
+            image = np.moveaxis(image, 0, 2)
 
-        for idx, signal_im in enumerate(list_signal_tmp):
-            background_im = list_background_tmp[idx]
-            images = self.__populate_array_with_cubes(
-                images, idx, signal_im, background_im
+            if self.augment:
+                # scale to isotropic, but don't scale back
+                image = augment(
+                    self.augmentation_parameters, image, scale_back=False
+                )
+
+            pixel_scalings = [
+                self.cube_height / image.shape[0],
+                self.cube_width / image.shape[1],
+                self.cube_depth / image.shape[2],  # type: ignore[misc]
+                # Not sure why mypy thinks .shape[2] is out of bounds above?
+            ]
+
+            # TODO: ensure this is always the correct size
+            image = zoom(image, pixel_scalings, order=self.interpolation_order)
+            return image
+
+        @staticmethod
+        def __get_batch_dict(cell_batch: List[Cell]) -> List[Dict[str, float]]:
+            return [cell.to_dict() for cell in cell_batch]
+
+        def on_epoch_end(self) -> None:
+            """
+            Shuffle data for each epoch
+            :return: Shuffled indexes
+            """
+            shuffle(self.batches)
+
+    class CubeGeneratorFromDisk(Sequence):
+        """
+        Reads in cubes from a list of paths for keras.Model.fit_generator() or
+        keras.Model.predict_generator()
+
+        If augment=True, each augmentation selected has a 50/50 chance of being
+        applied to each cube
+        """
+
+        def __init__(
+            self,
+            signal_list: List[Union[str, Path]],
+            background_list: List[Union[str, Path]],
+            labels: Optional[
+                List[int]
+            ] = None,  # only if training or validating
+            batch_size: int = 16,
+            shape: Tuple[int, int, int] = (50, 50, 20),
+            channels: int = 2,
+            classes: int = 2,
+            shuffle: bool = False,
+            augment: bool = False,
+            augment_likelihood: float = 0.1,
+            flip_axis: Tuple[int, int, int] = (0, 1, 2),
+            rotate_max_axes: Tuple[int, int, int] = (45, 45, 45),  # degrees
+            # scale=[0.5, 2],  # min, max
+            translate: Tuple[float, float, float] = (0.2, 0.2, 0.2),
+            train: bool = False,  # also return labels
+            interpolation_order: int = 2,
+        ):
+            self.im_shape = shape
+            self.batch_size = batch_size
+            self.labels = labels
+            self.signal_list = signal_list
+            self.background_list = background_list
+            self.channels = channels
+            self.classes = classes
+            self.augment = augment
+            self.augment_likelihood = augment_likelihood
+            self.flip_axis = flip_axis
+            self.rotate_max_axes = rotate_max_axes
+            # self.scale = scale
+            self.translate = translate
+            self.train = train
+            self.interpolation_order = interpolation_order
+            self.indexes = np.arange(len(self.signal_list))
+            if shuffle:
+                self.on_epoch_end()
+
+        # TODO: implement scale and shear
+
+        def on_epoch_end(self) -> None:
+            """
+            Shuffle data for each epoch
+            :return: Shuffled indexes
+            """
+            self.indexes = np.arange(len(self.signal_list))
+            np.random.shuffle(self.indexes)
+
+        def __len__(self) -> int:
+            """
+            Number of batches
+            :return: Number of batches per epoch
+            """
+            return int(np.ceil(len(self.signal_list) / self.batch_size))
+
+        def __getitem__(
+            self, index: int
+        ) -> Union[
+            np.ndarray,
+            Tuple[np.ndarray, List[Dict[str, float]]],
+            Tuple[np.ndarray, Dict],
+        ]:
+            """
+            Generates a single batch of cubes
+            :param index:
+            :return:
+            """
+            # Generate indexes of the batch
+            start_index = index * self.batch_size
+            end_index = start_index + self.batch_size
+            indexes = self.indexes[start_index:end_index]
+
+            # Get data corresponding to batch
+            list_signal_tmp = [self.signal_list[k] for k in indexes]
+            list_background_tmp = [self.background_list[k] for k in indexes]
+
+            images = self.__generate_cubes(
+                list_signal_tmp, list_background_tmp
             )
 
-        return images.astype(np.float16)
+            if self.train and self.labels is not None:
+                batch_labels = [self.labels[k] for k in indexes]
+                batch_labels = tf.keras.utils.to_categorical(
+                    batch_labels, num_classes=self.classes
+                )
+                return images, batch_labels
+            else:
+                return images
 
-    def __populate_array_with_cubes(
-        self,
-        images: np.ndarray,
-        idx: int,
-        signal_im: Union[str, Path],
-        background_im: Union[str, Path],
-    ) -> np.ndarray:
-        if self.augment:
-            self.augmentation_parameters = AugmentationParameters(
-                self.flip_axis,
-                self.translate,
-                self.rotate_max_axes,
-                self.interpolation_order,
-                self.augment_likelihood,
+        def __generate_cubes(
+            self,
+            list_signal_tmp: List[Union[str, Path]],
+            list_background_tmp: List[Union[str, Path]],
+        ) -> np.ndarray:
+            number_images = len(list_signal_tmp)
+            images = np.empty(
+                ((number_images,) + self.im_shape + (self.channels,))
             )
-        images[idx, :, :, :, 0] = self.__get_oriented_image(signal_im)
-        images[idx, :, :, :, 1] = self.__get_oriented_image(background_im)
 
-        return images
+            for idx, signal_im in enumerate(list_signal_tmp):
+                background_im = list_background_tmp[idx]
+                images = self.__populate_array_with_cubes(
+                    images, idx, signal_im, background_im
+                )
 
-    def __get_oriented_image(self, image_path: Union[str, Path]) -> np.ndarray:
-        # if paths are pathlib objs, skimage only reads one plane
-        image = np.moveaxis(imread(image_path), 0, 2)
-        if self.augment:
-            image = augment(self.augmentation_parameters, image)
-        return image
+            return images.astype(np.float16)
+
+        def __populate_array_with_cubes(
+            self,
+            images: np.ndarray,
+            idx: int,
+            signal_im: Union[str, Path],
+            background_im: Union[str, Path],
+        ) -> np.ndarray:
+            if self.augment:
+                self.augmentation_parameters = AugmentationParameters(
+                    self.flip_axis,
+                    self.translate,
+                    self.rotate_max_axes,
+                    self.interpolation_order,
+                    self.augment_likelihood,
+                )
+            images[idx, :, :, :, 0] = self.__get_oriented_image(signal_im)
+            images[idx, :, :, :, 1] = self.__get_oriented_image(background_im)
+
+            return images
+
+        def __get_oriented_image(
+            self, image_path: Union[str, Path]
+        ) -> np.ndarray:
+            # if paths are pathlib objs, skimage only reads one plane
+            image = np.moveaxis(imread(image_path), 0, 2)
+            if self.augment:
+                image = augment(self.augmentation_parameters, image)
+            return image
 
 
 def get_cube_depth_min_max(

--- a/src/cellfinder_core/classify/resnet.py
+++ b/src/cellfinder_core/classify/resnet.py
@@ -1,20 +1,26 @@
 from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
-from tensorflow import Tensor
-from tensorflow.keras import Model
-from tensorflow.keras.initializers import Initializer
-from tensorflow.keras.layers import (
-    Activation,
-    Add,
-    BatchNormalization,
-    Conv3D,
-    Dense,
-    GlobalAveragePooling3D,
-    Input,
-    MaxPooling3D,
-    ZeroPadding3D,
+from cellfinder_core.tensorflow_handle import (
+    _TENSORFLOW_INSTALLED,
+    tensorflow_required_function,
 )
-from tensorflow.keras.optimizers import Adam, Optimizer
+
+if _TENSORFLOW_INSTALLED:
+    from tensorflow import Tensor
+    from tensorflow.keras import Model
+    from tensorflow.keras.initializers import Initializer
+    from tensorflow.keras.layers import (
+        Activation,
+        Add,
+        BatchNormalization,
+        Conv3D,
+        Dense,
+        GlobalAveragePooling3D,
+        Input,
+        MaxPooling3D,
+        ZeroPadding3D,
+    )
+    from tensorflow.keras.optimizers import Adam, Optimizer
 
 #####################################################################
 # Define the types of ResNet
@@ -41,6 +47,7 @@ network_residual_bottleneck: Dict[layer_type, bool] = {
 #####################################################################
 
 
+@tensorflow_required_function
 def build_model(
     shape: Tuple[int, int, int, int] = (50, 50, 20, 2),
     network_depth: layer_type = "18-layer",
@@ -103,6 +110,7 @@ def get_resnet_blocks_and_bottleneck(
     return blocks, bottleneck
 
 
+@tensorflow_required_function
 def non_residual_block(
     inputs: Tensor,
     starting_features: int,
@@ -141,6 +149,7 @@ def non_residual_block(
     return x
 
 
+@tensorflow_required_function
 def residual_block(
     output_features: Tensor,
     resnet_unit_id: int,
@@ -285,6 +294,7 @@ def residual_block(
     return f
 
 
+@tensorflow_required_function
 def get_shortcut(
     inputs: Tensor,
     resnet_unit_label: int,

--- a/src/cellfinder_core/classify/tools.py
+++ b/src/cellfinder_core/classify/tools.py
@@ -2,13 +2,20 @@ import os
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
-import tensorflow as tf
-from tensorflow.keras import Model
 
 from cellfinder_core import logger
 from cellfinder_core.classify.resnet import build_model, layer_type
+from cellfinder_core.tensorflow_handle import (
+    _TENSORFLOW_INSTALLED,
+    tensorflow_required_function,
+)
+
+if _TENSORFLOW_INSTALLED:
+    import tensorflow as tf
+    from tensorflow.keras import Model
 
 
+@tensorflow_required_function
 def get_model(
     existing_model: Optional[os.PathLike] = None,
     model_weights: Optional[os.PathLike] = None,

--- a/src/cellfinder_core/tensorflow_handle.py
+++ b/src/cellfinder_core/tensorflow_handle.py
@@ -4,11 +4,8 @@ from typing import Any, Callable
 from warnings import warn
 
 # Handle tensorflow optional dependency
-_TENSORFLOW_INSTALLED = True
-_TF_VERSION = "0.0.0"
 try:
     _TF_VERSION = version("tensorflow")
-    import tensorflow as tf
 except PackageNotFoundError:
     # Optional tensorflow dependency not installed
     warn(
@@ -17,10 +14,9 @@ except PackageNotFoundError:
         "See [FIXME] for full details"
     )
     _TENSORFLOW_INSTALLED = False
-    # This will define the name tf even if tensorflow is not present.
-    # This allows us to apply the decorator to our code,
-    # avoiding large if-blocks within each function.
-    tf = None
+    _TF_VERSION = "0.0.0"
+else:
+    _TENSORFLOW_INSTALLED = True
 
 
 def tensorflow_required_function(fn_to_wrap: Callable) -> Any:
@@ -37,7 +33,7 @@ def tensorflow_required_function(fn_to_wrap: Callable) -> Any:
         if _TENSORFLOW_INSTALLED:
             fn_to_wrap()
         else:
-            raise RuntimeError(
+            raise ImportError(
                 f"[cellfinder-core].{fn_to_wrap.__name__}"
                 "requires tensorflow, which is not installed"
             )

--- a/src/cellfinder_core/tensorflow_handle.py
+++ b/src/cellfinder_core/tensorflow_handle.py
@@ -1,0 +1,45 @@
+from functools import wraps
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Callable
+from warnings import warn
+
+# Handle tensorflow optional dependency
+_TENSORFLOW_INSTALLED = True
+_TF_VERSION = "0.0.0"
+try:
+    _TF_VERSION = version("tensorflow")
+    import tensorflow as tf
+except PackageNotFoundError:
+    # Optional tensorflow dependency not installed
+    warn(
+        "cellfinder-core has been installed without tensorflow."
+        "Certain functions will be unavailable."
+        "See [FIXME] for full details"
+    )
+    _TENSORFLOW_INSTALLED = False
+    # This will define the name tf even if tensorflow is not present.
+    # This allows us to apply the decorator to our code,
+    # avoiding large if-blocks within each function.
+    tf = None
+
+
+def tensorflow_required_function(fn_to_wrap: Callable) -> Any:
+    """Decorator that marks functions as requiring the optional tensorflow
+    dependency to run.
+
+    Functions with this decorator applied will throw an error when they are
+    executed and the tensorflow package is not available.
+    Otherwise, the function will execute normally.
+    """
+
+    @wraps(fn_to_wrap)
+    def wrapped_fn():
+        if _TENSORFLOW_INSTALLED:
+            fn_to_wrap()
+        else:
+            raise RuntimeError(
+                f"[cellfinder-core].{fn_to_wrap.__name__}"
+                "requires tensorflow, which is not installed"
+            )
+
+    return wrapped_fn

--- a/src/cellfinder_core/tools/tf.py
+++ b/src/cellfinder_core/tools/tf.py
@@ -1,8 +1,9 @@
-import tensorflow as tf
-
 from cellfinder_core import logger
 
+from ..tensorflow_handle import tensorflow_required_function, tf
 
+
+@tensorflow_required_function
 def allow_gpu_memory_growth():
     """
     If a gpu is present, prevent tensorflow from using all the memory straight
@@ -27,6 +28,7 @@ def allow_gpu_memory_growth():
         logger.debug("No GPUs found, using CPU.")
 
 
+@tensorflow_required_function
 def set_tf_threads(max_threads):
     """
     Limit the number of threads that tensorflow uses

--- a/src/cellfinder_core/tools/tf.py
+++ b/src/cellfinder_core/tools/tf.py
@@ -1,6 +1,11 @@
 from cellfinder_core import logger
+from cellfinder_core.tensorflow_handle import (
+    _TENSORFLOW_INSTALLED,
+    tensorflow_required_function,
+)
 
-from ..tensorflow_handle import tensorflow_required_function, tf
+if _TENSORFLOW_INSTALLED:
+    import tensorflow as tf
 
 
 @tensorflow_required_function

--- a/src/cellfinder_core/train/train_yml.py
+++ b/src/cellfinder_core/train/train_yml.py
@@ -28,6 +28,7 @@ from sklearn.model_selection import train_test_split
 import cellfinder_core as program_for_log
 from cellfinder_core import logger
 from cellfinder_core.classify.resnet import layer_type
+from cellfinder_core.tensorflow_handle import tensorflow_required_function
 from cellfinder_core.tools.prep import DEFAULT_INSTALL_PATH
 
 tf_suppress_log_messages = [
@@ -297,6 +298,7 @@ def cli():
     )
 
 
+@tensorflow_required_function
 def run(
     output_dir,
     yaml_file,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
This resolves the tensorflow problem [as listed on this BrainGlobe repository issue.](https://github.com/brainglobe/BrainGlobe/issues/27)

Worth [looking at the alternative](https://github.com/brainglobe/BrainGlobe/issues/27#issuecomment-1617697328) solution proposed there too.

**What does this PR do?**
Makes `tensorflow` an optional dependency and include-guards all `tensorflow`-functionality that `cellfinder-core` uses in the event that the user does not have `tensorflow` installed.

(Although having examined this, it looks like this means that `cellfinder-core` simply doesn't have any functionality to offer).

## References

Please reference any existing issues/PRs that relate to this PR.

- Implements step 1 of https://github.com/brainglobe/BrainGlobe/issues/27

## How has this PR been tested?

## Is this a breaking change?

Yes - users now need to ensure they have `tensorflow` pre-installed in their environment, or explicitly _request_ it to be fetched along with `cellfinder-core` when they install.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
