### PR TITLE
Forbid import when `tensorflow` is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ pip install cellfinder-napari
 N.B. To speed up cellfinder, you need CUDA & cuDNN installed. Instructions
 [here](https://brainglobe.info/documentation/general/gpu.html).
 
+#### Conda Install
+`cellfinder-core` is available on `conda-forge`, however `tensorflow`, one of it's core dependencies, is not.
+As a result; you _must_ manually install `tensorflow` into your environment - whether you do this before or after `conda install`ing doesn't matter.
+Once you are ready, install `cellfinder-core` into the desired environment via conda;
+```sh
+conda install -c conda-forge cellfinder-core
+```
+
+Please bear in mind that running the `conda install` command above will exit without failing even if `tensorflow` is not present; however `tensorflow` will not be installed as part of this process, and thus `cellfinder-core` will not be usable.
+
 ### Usage
 Before using cellfinder-core, it may be useful to take a look at the
 [paper](https://doi.org/10.1371/journal.pcbi.1009074) which

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -5,6 +5,18 @@ try:
 except PackageNotFoundError as e:
     raise PackageNotFoundError("cellfinder-core package not installed") from e
 
+# If tensorflow is not present, tools cannot be used.
+# Throw an error in this case to prevent invocation of functions.
+try:
+    TF_VERSION = version("tensorflow")
+except PackageNotFoundError as e:
+    raise PackageNotFoundError(
+        f"cellfinder tools cannot be invoked without tensorflow. "
+        f"Please install tensorflow into your environment to use cellfinder tools. "
+        f"For more information, please see "
+        f"https://github.com/brainglobe/brainglobe-meta#readme."
+    ) from e
+
 __author__ = "Adam Tyson, Christian Niedworok, Charly Rousseau"
 __license__ = "BSD-3-Clause"
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
See https://github.com/brainglobe/BrainGlobe/issues/27 - this PR is for `conda-forge` compatibility reasons.

**What does this PR do?**
This PR forbids the import of `cellfinder_core` when `tensorflow` is not installed.

Note that we do not need to remove `tensorflow` from the `pyproject.toml` dependencies - these are read only by `pip` and not by `conda`.

## References

[Resolves step 1 of this issue.](https://github.com/brainglobe/BrainGlobe/issues/27)

## How has this PR been tested?

Local testing of `pip` package install:
```sh
$ conda activate cellfinder
(cellfinder) $ pip install .
(cellfinder) $ python 
>> import cellfinder_core
# All good
>> exit()
(cellfinder) $ pip uninstall tensorflow
(cellfinder) $ python
>> import cellfinder_core
# Throws expected error
(cellfinder) $ pip install tensorflow
(cellfinder) $ python
>> import cellfinder_core
# All good again
>> exit()
```

## Is this a breaking change?
No. New version, PyPI upload, and conda-forge recipe required though.

## Does this PR require an update to the documentation?
Updates README to explain that the conda-install will not fetch tensorflow, this will have to be done by the user.

Requires a change on `brainglobe-meta` repository.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
