### PR TITLE
CI Check against `tensorflow` include guard

### DIFF
--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -45,8 +45,14 @@ jobs:
             import cellfinder_core
 
       # exit 1 will force an actions exit with a failure reported
-      - name: Check error was thrown by broken import
+      - name: Flag error thrown by broken import
         if: steps.broken_import.outputs.error == 'false'
         run: |
           echo "Broken import test result was: ${{ steps.broken_import.outputs.error }}"
           exit 1
+
+      # add an additional step to confirm an error occurred in the import
+      - name: Confirm error was thrown by broken import
+        if: steps.broken_import.outputs.error == 'true'
+        run: |
+          echo "Broken import test result was: ${{ steps.broken_import.outputs.error }}"

--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -34,7 +34,7 @@ jobs:
             import cellfinder_core
 
       - name: Uninstall tensorflow
-        run: python -m pip uninstall tensorflow
+        run: python -m pip uninstall -y tensorflow
 
       - name: Test (broken) import
         id: broken_import

--- a/.github/workflows/test_include_guard.yaml
+++ b/.github/workflows/test_include_guard.yaml
@@ -1,0 +1,52 @@
+name: Test Tensorflow include guards
+# These tests check that the include guards checking for tensorflow's availability
+# behave as expected on ubuntu and macOS.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tensorflow_guards:
+    name: Test include guards
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install via pip
+        run: python -m pip install -e .
+
+      - name: Test (working) import
+        uses: jannekem/run-python-script-action@v1
+        with:
+          fail-on-error: true
+          script: |
+            import cellfinder_core
+
+      - name: Uninstall tensorflow
+        run: python -m pip uninstall tensorflow
+
+      - name: Test (broken) import
+        id: broken_import
+        uses: jannekem/run-python-script-action@v1
+        with:
+          fail-on-error: false
+          script: |
+            import cellfinder_core
+
+      # exit 1 will force an actions exit with a failure reported
+      - name: Check error was thrown by broken import
+        if: steps.broken_import.outputs.error == 'false'
+        run: |
+          echo "Broken import test result was: ${{ steps.broken_import.outputs.error }}"
+          exit 1


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Tests the include-guard that denies use of the tools when `tensorflow` is not available.

**What does this PR do?**

Adds a short check to make sure that the `tensorflow` include guard is behaving itself on `ubuntu` and `macOS`.
- `pip install -e .` should successfully fetch `tensorflow` and allow import.
- If `tensorflow` is not installed, importing the module should fail. Conditions for this test are achieved by having pip uninstall `tensorflow`.

## References

- Closes #203 

## How has this PR been tested?

Locally running the commands produces the outcomes that are checked against.
New workflow has been introduced to check the results are as expected on CI.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
