### PR TITLE
Prepare for retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# This package has moved!
+
+`cellfinder-core` has merged with it's napari plugin and is now available as a [single package called `cellfinder`](https://github.com/brainglobe/cellfinder).
+We recommend you uninstall `cellfinder-core` and instead use the functionality provided in the `cellfinder` package.
+
+These changes are part of our [wider restructuring](https://brainglobe.info/blog/version1/version_1_announcement.html) of the BrainGlobe suite of tools and analysis pipelines, which you can [keep up to date with on our blog](https://brainglobe.info/blog/index.html).
+
+---
+
 [![Python Version](https://img.shields.io/pypi/pyversions/cellfinder-core.svg)](https://pypi.org/project/cellfinder-core)
 [![PyPI](https://img.shields.io/pypi/v/cellfinder-core.svg)](https://pypi.org/project/cellfinder-core)
 [![Downloads](https://pepy.tech/badge/cellfinder-core)](https://pepy.tech/project/cellfinder-core)

--- a/src/cellfinder_core/__init__.py
+++ b/src/cellfinder_core/__init__.py
@@ -1,3 +1,10 @@
+from warnings import warn
+
+warn(
+    f"cellfinder-core has merged with it's napari plugin and is now available as a combined package. To remain up to date, please install cellfinder: https://github.com/brainglobe/cellfinder",
+    DeprecationWarning,
+)
+
 from importlib.metadata import PackageNotFoundError, version
 
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
     3.10: py310
 
 [testenv]
-commands = python -m pytest -v --color=yes
+commands = python -m pytest -v --color=yes -W ignore::DeprecationWarning
 deps =
     pytest
     pytest-cov


### PR DESCRIPTION
Marks the package for deprecation, as per https://github.com/brainglobe/BrainGlobe/issues/46.

Merging to be followed by a new version release, at `==v1.0.0`. This allows users to revert to <v1.0.0 if they don't want the wider BrainGlobe v1.

Rebase onto `main` recommended before merging, to catch any additional changes.